### PR TITLE
Moved project declarations before include common.cmake

### DIFF
--- a/Intro-Full/Exercises/01/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/01/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial01)
 include(../../common.cmake)
 
-project (KokkosTutorial01)
 add_executable(01_Exercise exercise_1_begin.cpp)
 target_link_libraries(01_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/01/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/01/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial01)
 include(../../common.cmake)
 
-project (KokkosTutorial01)
 add_executable(01_Exercise exercise_1_solution.cpp)
 target_link_libraries(01_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/02/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/02/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial02)
 include(../../common.cmake)
 
-project (KokkosTutorial02)
 add_executable(02_Exercise exercise_2_begin.cpp)
 target_link_libraries(02_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/02/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/02/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial02)
 include(../../common.cmake)
 
-project (KokkosTutorial02)
 add_executable(02_Exercise exercise_2_solution.cpp)
 target_link_libraries(02_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/03/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/03/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial03)
 include(../../common.cmake)
 
-project (KokkosTutorial03)
 add_executable(03_Exercise exercise_3_begin.cpp)
 target_link_libraries(03_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/03/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/03/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial03)
 include(../../common.cmake)
 
-project (KokkosTutorial03)
 add_executable(03_Exercise exercise_3_solution.cpp)
 target_link_libraries(03_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/04/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/04/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial04)
 include(../../common.cmake)
 
-project (KokkosTutorial04)
 add_executable(04_Exercise exercise_4_begin.cpp)
 target_link_libraries(04_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/04/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/04/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial04)
 include(../../common.cmake)
 
-project (KokkosTutorial04)
 add_executable(04_Exercise exercise_4_solution.cpp)
 target_link_libraries(04_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/05/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/05/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial05)
 include(../../common.cmake)
 
-project (KokkosTutorial05)
 add_executable(05_Exercise exercise_5_begin.cpp)
 target_link_libraries(05_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/05/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/05/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial05)
 include(../../common.cmake)
 
-project (KokkosTutorial05)
 add_executable(05_Exercise exercise_5_solution.cpp)
 target_link_libraries(05_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/06/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/06/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial06)
 include(../../common.cmake)
 
-project (KokkosTutorial06)
 add_executable(06_Exercise exercise_6_begin.cpp)
 target_link_libraries(06_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/06/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/06/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial06)
 include(../../common.cmake)
 
-project (KokkosTutorial06)
 add_executable(06_Exercise exercise_6_solution.cpp)
 target_link_libraries(06_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/07/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/07/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial07)
 include(../../common.cmake)
 
-project (KokkosTutorial07)
 add_executable(07_Exercise exercise_7_begin.cpp)
 target_link_libraries(07_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/07/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/07/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial07)
 include(../../common.cmake)
 
-project (KokkosTutorial07)
 add_executable(07_Exercise exercise_7_solution.cpp)
 target_link_libraries(07_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/08/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/08/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial08)
 include(../../common.cmake)
 
-project (KokkosTutorial08)
 add_executable(08_Exercise exercise_8_begin.cpp)
 target_link_libraries(08_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/08/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/08/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial08)
 include(../../common.cmake)
 
-project (KokkosTutorial08)
 add_executable(08_Exercise exercise_8_solution.cpp)
 target_link_libraries(08_Exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/common.cmake
+++ b/Intro-Full/Exercises/common.cmake
@@ -2,9 +2,9 @@
 set(SPACK_CXX $ENV{SPACK_CXX})
 if(SPACK_CXX)
   message("found spack compiler ${SPACK_CXX}")
-  set(CMAKE_CXX_COMPILER ${SPACK_CXX} CACHE STRING "the C++ compiler" FORCE)  
+  set(CMAKE_CXX_COMPILER ${SPACK_CXX} CACHE STRING "the C++ compiler" FORCE)
   set(ENV{CXX} ${SPACK_CXX})
 endif()
 
-cmake_policy(SET CMP0074 NEW)
+set(Kokkos_ROOT_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(Kokkos REQUIRED)

--- a/Intro-Full/Exercises/common.cmake
+++ b/Intro-Full/Exercises/common.cmake
@@ -6,5 +6,5 @@ if(SPACK_CXX)
   set(ENV{CXX} ${SPACK_CXX})
 endif()
 
-set(Kokkos_ROOT_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
+set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(Kokkos REQUIRED)

--- a/Intro-Full/Exercises/dualview/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/dualview/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialDualView)
 include(../../common.cmake)
 
-project (KokkosTutorialDualView)
 add_executable(dualview dual_view_exercise.cpp)
 target_link_libraries(dualview Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/dualview/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/dualview/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialDualView)
 include(../../common.cmake)
 
-project (KokkosTutorialDualView)
 add_executable(dualview dual_view_exercise.cpp)
 target_link_libraries(dualview Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/fortran-kokkosinterface/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/fortran-kokkosinterface/Begin/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialFortran)
 include(../../common.cmake)
 
 enable_language(Fortran)
@@ -6,18 +7,17 @@ enable_language(Fortran)
 set(SPACK_FC $ENV{SPACK_FC})
 if(SPACK_FC)
   message("Found spack fortran compiler ${SPACK_FC}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_FC} CACHE STRING "the C++ compiler" FORCE)  
+  set(CMAKE_Fortran_COMPILER ${SPACK_FC} CACHE STRING "the C++ compiler" FORCE)
   set(ENV{FC} ${SPACK_FC})
 endif()
 
 set(SPACK_F77 $ENV{SPACK_F77})
 if(SPACK_F77)
   message("Found spack fortran compiler ${SPACK_F77}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_F77} CACHE STRING "the C++ compiler" FORCE)  
+  set(CMAKE_Fortran_COMPILER ${SPACK_F77} CACHE STRING "the C++ compiler" FORCE)
   set(ENV{F77} ${SPACK_F77})
 endif()
 
-project (KokkosTutorialFortran)
 add_executable(ftest.x abi.f90 f_interface.f90 main.f90 c_interface.cpp)
 target_link_libraries(ftest.x Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/fortran-kokkosinterface/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/fortran-kokkosinterface/Solution/CMakeLists.txt
@@ -1,17 +1,18 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialFortran)
 include(../../common.cmake)
 
 set(SPACK_FC $ENV{SPACK_FC})
 if(SPACK_FC)
   message("Found spack fortran compiler ${SPACK_FC}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_FC} CACHE FILEPATH "the C++ compiler" FORCE)  
+  set(CMAKE_Fortran_COMPILER ${SPACK_FC} CACHE FILEPATH "the C++ compiler" FORCE)
   set(ENV{FC} ${SPACK_FC})
 endif()
 
 set(SPACK_F77 $ENV{SPACK_F77})
 if(SPACK_F77)
   message("Found spack fortran compiler ${SPACK_F77}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_F77} CACHE FILEPATH "the C++ compiler" FORCE)  
+  set(CMAKE_Fortran_COMPILER ${SPACK_F77} CACHE FILEPATH "the C++ compiler" FORCE)
   set(ENV{F77} ${SPACK_F77})
 endif()
 
@@ -23,7 +24,6 @@ message("${outVar}")
 
 enable_language(Fortran)
 
-project (KokkosTutorialFortran)
 add_executable(ftest.x abi.f90 f_interface.f90 main.f90 c_interface.cpp)
 target_link_libraries(ftest.x Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/kokkoskernels/CGSolve/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/kokkoskernels/CGSolve/Begin/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosKernelsCGSolve)
 include(../../common.cmake)
 
-project (KokkosKernelsCGSolve)
 add_executable(cgsolve cgsolve.cpp)
-
 target_link_libraries(cgsolve Kokkos::kokkoskernels)
 
 

--- a/Intro-Full/Exercises/kokkoskernels/CGSolve/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/kokkoskernels/CGSolve/Solution/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosKernelsCGSolve)
 include(../../common.cmake)
 
-project (KokkosKernelsCGSolve)
 add_executable(cgsolve cgsolve.cpp)
-
 target_link_libraries(cgsolve Kokkos::kokkoskernels)
 
 

--- a/Intro-Full/Exercises/kokkoskernels/InnerProduct/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/kokkoskernels/InnerProduct/Begin/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosKernelsInnerProduct)
 include(../../common.cmake)
 
-project (KokkosKernelsInnerProduct)
 add_executable(inner innerproduct.cpp)
-
 target_link_libraries(inner Kokkos::kokkoskernels)
 
 

--- a/Intro-Full/Exercises/kokkoskernels/InnerProduct/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/kokkoskernels/InnerProduct/Solution/CMakeLists.txt
@@ -1,9 +1,8 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosKernelsInnerProduct)
 include(../../common.cmake)
 
-project (KokkosKernelsInnerProduct)
 add_executable(inner innerproduct.cpp)
-
 target_link_libraries(inner Kokkos::kokkoskernels)
 
 

--- a/Intro-Full/Exercises/mdrange/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/mdrange/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialMdRange)
 include(../../common.cmake)
 
-project (KokkosTutorialMdRange)
 add_executable(mdrange_exercise exercise_mdrange_begin.cpp)
 target_link_libraries(mdrange_exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/mdrange/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/mdrange/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialMdRange)
 include(../../common.cmake)
 
-project (KokkosTutorialMdRange)
 add_executable(mdrange_exercise exercise_mdrange_solution.cpp)
 target_link_libraries(mdrange_exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/random_number/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/random_number/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialRNG)
 include(../../common.cmake)
 
-project (KokkosTutorialRNG)
 add_executable(MC_DartSampler MC_DartSampler.cpp)
 target_link_libraries(MC_DartSampler Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/random_number/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/random_number/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialRNG)
 include(../../common.cmake)
 
-project (KokkosTutorialRNG)
 add_executable(MC_DartSampler MC_DartSampler.cpp)
 target_link_libraries(MC_DartSampler Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/scatter_view/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/scatter_view/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialScatterView)
 include(../../common.cmake)
 
-project (KokkosTutorialScatterView)
 add_executable(scatterview fe_scatter.cpp)
 target_link_libraries(scatterview Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/scatter_view/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/scatter_view/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialScatterView)
 include(../../common.cmake)
 
-project (KokkosTutorialScatterView)
 add_executable(scatterview fe_scatter.cpp)
 target_link_libraries(scatterview Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/subview/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/subview/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialSubview)
 include(../../common.cmake)
 
-project (KokkosTutorialSubview)
 add_executable(subview_exercise exercise_subview_begin.cpp)
 target_link_libraries(subview_exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/subview/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/subview/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialSubview)
 include(../../common.cmake)
 
-project (KokkosTutorialSubview)
 add_executable(subview_exercise exercise_subview_solution.cpp)
 target_link_libraries(subview_exercise Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/unordered_map/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/unordered_map/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialUnorderedMap)
 include(../../common.cmake)
 
-project (KokkosTutorialUnorderedMap)
 add_executable(unordered_map unordered_map.cpp)
 target_link_libraries(unordered_map Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/unordered_map/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/unordered_map/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialUnorderedMap)
 include(../../common.cmake)
 
-project (KokkosTutorialUnorderedMap)
 add_executable(unordered_map unordered_map.cpp)
 target_link_libraries(unordered_map Kokkos::kokkos)
 

--- a/Intro-Full/Exercises/virtualfunction/Begin/CMakeLists.txt
+++ b/Intro-Full/Exercises/virtualfunction/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialVirtualFunction)
 include(../../common.cmake)
 
-project (KokkosTutorialVirtualFunction)
 add_executable(virtual_function virtual_function.cpp classes.cpp)
 target_link_libraries(virtual_function Kokkos::kokkos)
 target_include_directories(virtual_function PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Intro-Full/Exercises/virtualfunction/Solution/CMakeLists.txt
+++ b/Intro-Full/Exercises/virtualfunction/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorialVirtualFunction)
 include(../../common.cmake)
 
-project (KokkosTutorialVirtualFunction)
 add_executable(virtual_function virtual_function.cpp classes.cpp)
 target_link_libraries(virtual_function Kokkos::kokkos)
 target_include_directories(virtual_function PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/Intro-Short/Exercises/01/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/01/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial01)
 include(../../common.cmake)
 
-project (KokkosTutorial01)
 add_executable(01_Exercise exercise_1_begin.cpp)
 target_link_libraries(01_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/01/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/01/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial01)
 include(../../common.cmake)
 
-project (KokkosTutorial01)
 add_executable(01_Exercise exercise_1_solution.cpp)
 target_link_libraries(01_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/02/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/02/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial02)
 include(../../common.cmake)
 
-project (KokkosTutorial02)
 add_executable(02_Exercise exercise_2_begin.cpp)
 target_link_libraries(02_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/02/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/02/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial02)
 include(../../common.cmake)
 
-project (KokkosTutorial02)
 add_executable(02_Exercise exercise_2_solution.cpp)
 target_link_libraries(02_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/03/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/03/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial03)
 include(../../common.cmake)
 
-project (KokkosTutorial03)
 add_executable(03_Exercise exercise_3_begin.cpp)
 target_link_libraries(03_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/03/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/03/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial03)
 include(../../common.cmake)
 
-project (KokkosTutorial03)
 add_executable(03_Exercise exercise_3_solution.cpp)
 target_link_libraries(03_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/04/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/04/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial04)
 include(../../common.cmake)
 
-project (KokkosTutorial04)
 add_executable(04_Exercise exercise_4_begin.cpp)
 target_link_libraries(04_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/04/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/04/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial04)
 include(../../common.cmake)
 
-project (KokkosTutorial04)
 add_executable(04_Exercise exercise_4_solution.cpp)
 target_link_libraries(04_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/05/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/05/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial05)
 include(../../common.cmake)
 
-project (KokkosTutorial05)
 add_executable(05_Exercise exercise_5_begin.cpp)
 target_link_libraries(05_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/05/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/05/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial05)
 include(../../common.cmake)
 
-project (KokkosTutorial05)
 add_executable(05_Exercise exercise_5_solution.cpp)
 target_link_libraries(05_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/06/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/06/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial06)
 include(../../common.cmake)
 
-project (KokkosTutorial06)
 add_executable(06_Exercise exercise_6_begin.cpp)
 target_link_libraries(06_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/06/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/06/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial06)
 include(../../common.cmake)
 
-project (KokkosTutorial06)
 add_executable(06_Exercise exercise_6_solution.cpp)
 target_link_libraries(06_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/07/Begin/CMakeLists.txt
+++ b/Intro-Short/Exercises/07/Begin/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial07)
 include(../../common.cmake)
 
-project (KokkosTutorial07)
 add_executable(07_Exercise exercise_7_begin.cpp)
 target_link_libraries(07_Exercise Kokkos::kokkos)
 

--- a/Intro-Short/Exercises/07/Solution/CMakeLists.txt
+++ b/Intro-Short/Exercises/07/Solution/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.10)
+project (KokkosTutorial07)
 include(../../common.cmake)
 
-project (KokkosTutorial07)
 add_executable(07_Exercise exercise_7_solution.cpp)
 target_link_libraries(07_Exercise Kokkos::kokkos)
 


### PR DESCRIPTION
`include(../../common.cmake)` before `project(...)` produces this warning when shared libraries are used:

```console
CMake Warning (dev) at /usr/local/lib/cmake/Kokkos/KokkosTargets.cmake:54 (add_library):
  ADD_LIBRARY called with SHARED option but the target platform does not
  support dynamic linking.  Building a STATIC library instead.  This may lead
  to problems.
Call Stack (most recent call first):
  /usr/local/lib/cmake/Kokkos/KokkosConfig.cmake:45 (INCLUDE)
  /home/kokkos/tutorials/Intro-Full/Exercises/common.cmake:10 (find_package)
  CMakeLists.txt:2 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```