### PR TITLE
Update exercise_4_solution.cpp

### DIFF
--- a/Intro-Full/Exercises/04/Solution/exercise_4_solution.cpp
+++ b/Intro-Full/Exercises/04/Solution/exercise_4_solution.cpp
@@ -107,7 +107,7 @@ int main( int argc, char* argv[] )
   #endif
 
   using ExecSpace = MemSpace::execution_space;
-  using range_policy = Kokkos::RangePolicy<ExecSpace>
+  using range_policy = Kokkos::RangePolicy<ExecSpace>;
 
   // Allocate y, x vectors and Matrix A on device.
   typedef Kokkos::View<double*, Kokkos::LayoutLeft, MemSpace>   ViewVectorType;


### PR DESCRIPTION
exercise_4_solution.cpp: In function ‘int main(int, char**)’:
exercise_4_solution.cpp:110:54: error: expected ‘;’ before ‘typedef’
  110 |   using range_policy = Kokkos::RangePolicy<ExecSpace>