### PR TITLE
Bump CMake minimum requirement 3.10 -> 3.16 in the exercises

### DIFF
--- a/Exercises/01/Begin/CMakeLists.txt
+++ b/Exercises/01/Begin/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial01)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial01)
 include(../../common.cmake)
 
 add_executable(01_Exercise exercise_1_begin.cpp)
 target_link_libraries(01_Exercise Kokkos::kokkos)
-
 

--- a/Exercises/01/Solution/CMakeLists.txt
+++ b/Exercises/01/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial01)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial01)
 include(../../common.cmake)
 
 add_executable(01_Exercise exercise_1_solution.cpp)

--- a/Exercises/02/Begin/CMakeLists.txt
+++ b/Exercises/02/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial02)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial02)
 include(../../common.cmake)
 
 add_executable(02_Exercise exercise_2_begin.cpp)

--- a/Exercises/02/Solution/CMakeLists.txt
+++ b/Exercises/02/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial02)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial02)
 include(../../common.cmake)
 
 add_executable(02_Exercise exercise_2_solution.cpp)

--- a/Exercises/03/Begin/CMakeLists.txt
+++ b/Exercises/03/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial03)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial03)
 include(../../common.cmake)
 
 add_executable(03_Exercise exercise_3_begin.cpp)

--- a/Exercises/03/Solution/CMakeLists.txt
+++ b/Exercises/03/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial03)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial03)
 include(../../common.cmake)
 
 add_executable(03_Exercise exercise_3_solution.cpp)

--- a/Exercises/04/Begin/CMakeLists.txt
+++ b/Exercises/04/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial04)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial04)
 include(../../common.cmake)
 
 add_executable(04_Exercise exercise_4_begin.cpp)

--- a/Exercises/04/Solution/CMakeLists.txt
+++ b/Exercises/04/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorial04)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorial04)
 include(../../common.cmake)
 
 add_executable(04_Exercise exercise_4_solution.cpp)

--- a/Exercises/common.cmake
+++ b/Exercises/common.cmake
@@ -6,5 +6,4 @@ if(SPACK_CXX)
   set(ENV{CXX} ${SPACK_CXX})
 endif()
 
-set(Kokkos_DIR "$ENV{Kokkos_ROOT}" CACHE STRING "Kokkos root directory")
 find_package(Kokkos REQUIRED)

--- a/Exercises/dualview/Begin/CMakeLists.txt
+++ b/Exercises/dualview/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialDualView)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialDualView)
 include(../../common.cmake)
 
 add_executable(dualview dual_view_exercise.cpp)

--- a/Exercises/dualview/Solution/CMakeLists.txt
+++ b/Exercises/dualview/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialDualView)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialDualView)
 include(../../common.cmake)
 
 add_executable(dualview dual_view_exercise.cpp)

--- a/Exercises/fortran-kokkosinterface/Begin/CMakeLists.txt
+++ b/Exercises/fortran-kokkosinterface/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialFortran)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialFortran)
 include(../../common.cmake)
 
 enable_language(Fortran)

--- a/Exercises/fortran-kokkosinterface/Solution/CMakeLists.txt
+++ b/Exercises/fortran-kokkosinterface/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialFortran)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialFortran)
 include(../../common.cmake)
 
 set(SPACK_FC $ENV{SPACK_FC})

--- a/Exercises/kokkoskernels/BlockJacobi/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/BlockJacobi/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsBlockjacobi)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsBlockjacobi)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/BlockJacobi/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/BlockJacobi/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsBlockjacobi)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsBlockjacobi)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/CGSolve/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/CGSolve/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsCGSolve)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsCGSolve)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/CGSolve/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/CGSolve/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsCGSolve)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsCGSolve)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsCGSolve)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsCGSolve)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsCGSolve)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsCGSolve)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/GaussSeidel/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/GaussSeidel/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsGaussSeidel)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsGaussSeidel)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/GaussSeidel/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/GaussSeidel/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsGaussSeidel)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsGaussSeidel)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/GraphColoring/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/GraphColoring/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsGraphColoring)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsGraphColoring)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/GraphColoring/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/GraphColoring/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsGraphColoring)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsGraphColoring)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/InnerProduct/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/InnerProduct/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsInnerProduct)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsInnerProduct)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/InnerProduct/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/InnerProduct/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsInnerProduct)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsInnerProduct)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/SpGEMM/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/SpGEMM/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsSpGEMM)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsSpGEMM)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/SpGEMM/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/SpGEMM/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsSpGEMM)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsSpGEMM)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/SpILUK/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/SpILUK/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsSpILUK)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsSpILUK)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/SpILUK/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/SpILUK/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsSpILUK)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsSpILUK)
 
 find_package(KokkosKernels REQUIRED)
 

--- a/Exercises/kokkoskernels/TeamGemm/Begin/CMakeLists.txt
+++ b/Exercises/kokkoskernels/TeamGemm/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsTeamGemm)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsTeamGemm)
 include(../../common.cmake)
 
 add_executable(teamgemm teamgemm.cpp)

--- a/Exercises/kokkoskernels/TeamGemm/Solution/CMakeLists.txt
+++ b/Exercises/kokkoskernels/TeamGemm/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosKernelsTeamGemm)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosKernelsTeamGemm)
 include(../../common.cmake)
 
 add_executable(teamgemm teamgemm.cpp)

--- a/Exercises/kokkoskernels/common.cmake
+++ b/Exercises/kokkoskernels/common.cmake
@@ -6,5 +6,4 @@ if(SPACK_CXX)
   set(ENV{CXX} ${SPACK_CXX})
 endif()
 
-cmake_policy(SET CMP0074 NEW)
 find_package(KokkosKernels REQUIRED)

--- a/Exercises/mdrange/Begin/CMakeLists.txt
+++ b/Exercises/mdrange/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialMdRange)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialMdRange)
 include(../../common.cmake)
 
 add_executable(mdrange_exercise exercise_mdrange_begin.cpp)

--- a/Exercises/mdrange/Solution/CMakeLists.txt
+++ b/Exercises/mdrange/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialMdRange)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialMdRange)
 include(../../common.cmake)
 
 add_executable(mdrange_exercise exercise_mdrange_solution.cpp)

--- a/Exercises/mpi_pack_unpack/Begin/CMakeLists.txt
+++ b/Exercises/mpi_pack_unpack/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialMPIPackUnpack)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialMPIPackUnpack)
 include(../../common.cmake)
 
 add_executable(MPIPackUnpack mpi_pack_unpack_begin.cpp)

--- a/Exercises/mpi_pack_unpack/Solution/CMakeLists.txt
+++ b/Exercises/mpi_pack_unpack/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialMPIPackUnpack)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialMPIPackUnpack)
 include(../../common.cmake)
 
 add_executable(MPIPackUnpack mpi_pack_unpack_solution.cpp)

--- a/Exercises/random_number/Begin/CMakeLists.txt
+++ b/Exercises/random_number/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialRNG)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialRNG)
 include(../../common.cmake)
 
 add_executable(MC_DartSampler MC_DartSampler.cpp)

--- a/Exercises/random_number/Solution/CMakeLists.txt
+++ b/Exercises/random_number/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialRNG)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialRNG)
 include(../../common.cmake)
 
 add_executable(MC_DartSampler MC_DartSampler.cpp)

--- a/Exercises/scatter_view/Begin/CMakeLists.txt
+++ b/Exercises/scatter_view/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialScatterView)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialScatterView)
 include(../../common.cmake)
 
 add_executable(scatterview fe_scatter.cpp)

--- a/Exercises/scatter_view/Solution/CMakeLists.txt
+++ b/Exercises/scatter_view/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialScatterView)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialScatterView)
 include(../../common.cmake)
 
 add_executable(scatterview scatter_view.cpp)

--- a/Exercises/simd/Begin/CMakeLists.txt
+++ b/Exercises/simd/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialSIMD)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialSIMD)
 include(../../common.cmake)
 
 add_executable(SIMD simd_begin.cpp)

--- a/Exercises/simd/Solution/CMakeLists.txt
+++ b/Exercises/simd/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialSIMD)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialSIMD)
 include(../../common.cmake)
 
 add_executable(SIMD simd_solution.cpp)

--- a/Exercises/simd_warp/Begin/CMakeLists.txt
+++ b/Exercises/simd_warp/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialSIMDWarp)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialSIMDWarp)
 include(../../common.cmake)
 
 add_executable(SIMDWarp simd_warp_begin.cpp)

--- a/Exercises/simd_warp/Solution/CMakeLists.txt
+++ b/Exercises/simd_warp/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialSIMDWarp)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialSIMDWarp)
 include(../../common.cmake)
 
 add_executable(SIMDWarp simd_warp_solution.cpp)

--- a/Exercises/subview/Begin/CMakeLists.txt
+++ b/Exercises/subview/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialSubview)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialSubview)
 include(../../common.cmake)
 
 add_executable(subview_exercise exercise_subview_begin.cpp)

--- a/Exercises/subview/Solution/CMakeLists.txt
+++ b/Exercises/subview/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialSubview)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialSubview)
 include(../../common.cmake)
 
 add_executable(subview_exercise exercise_subview_solution.cpp)

--- a/Exercises/tasking/Begin/CMakeLists.txt
+++ b/Exercises/tasking/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTasking)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTasking)
 include(../../common.cmake)
 
 add_executable(Tasking tasking_begin.cpp)

--- a/Exercises/tasking/Solution/CMakeLists.txt
+++ b/Exercises/tasking/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTasking)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTasking)
 include(../../common.cmake)
 
 add_executable(Tasking tasking_solution.cpp)

--- a/Exercises/team_policy/Begin/CMakeLists.txt
+++ b/Exercises/team_policy/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTeamPolicy)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTeamPolicy)
 include(../../common.cmake)
 
 add_executable(TeamPolicy team_policy_begin.cpp)

--- a/Exercises/team_policy/Solution/CMakeLists.txt
+++ b/Exercises/team_policy/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTeamPolicy)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTeamPolicy)
 include(../../common.cmake)
 
 add_executable(TeamPolicy team_policy_solution.cpp)

--- a/Exercises/team_scratch_memory/Begin/CMakeLists.txt
+++ b/Exercises/team_scratch_memory/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTeamScratchMemory)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTeamScratchMemory)
 include(../../common.cmake)
 
 add_executable(TeamScratchMemory team_scratch_memory_begin.cpp)

--- a/Exercises/team_scratch_memory/Solution/CMakeLists.txt
+++ b/Exercises/team_scratch_memory/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTeamScratchMemory)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTeamScratchMemory)
 include(../../common.cmake)
 
 add_executable(TeamScratchMemory team_scratch_memory_solution.cpp)

--- a/Exercises/team_vector_loop/Begin/CMakeLists.txt
+++ b/Exercises/team_vector_loop/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTeamVectorLoop)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTeamVectorLoop)
 include(../../common.cmake)
 
 add_executable(TeamVectorLoop team_vector_loop_begin.cpp)

--- a/Exercises/team_vector_loop/Solution/CMakeLists.txt
+++ b/Exercises/team_vector_loop/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialTeamVectorLoop)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialTeamVectorLoop)
 include(../../common.cmake)
 
 add_executable(TeamVectorLoop team_vector_loop_solution.cpp)

--- a/Exercises/unique_token/Begin/CMakeLists.txt
+++ b/Exercises/unique_token/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialUniqueToken)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialUniqueToken)
 include(../../common.cmake)
 
 add_executable(uniquetoken unique_token.cpp)

--- a/Exercises/unique_token/Solution/CMakeLists.txt
+++ b/Exercises/unique_token/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialUniqueToken)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialUniqueToken)
 include(../../common.cmake)
 
 add_executable(uniquetoken unique_token.cpp)

--- a/Exercises/unordered_map/Begin/CMakeLists.txt
+++ b/Exercises/unordered_map/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialUnorderedMap)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialUnorderedMap)
 include(../../common.cmake)
 
 add_executable(unordered_map unordered_map.cpp)

--- a/Exercises/unordered_map/Solution/CMakeLists.txt
+++ b/Exercises/unordered_map/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialUnorderedMap)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialUnorderedMap)
 include(../../common.cmake)
 
 add_executable(unordered_map unordered_map.cpp)

--- a/Exercises/vectorshift/Begin/CMakeLists.txt
+++ b/Exercises/vectorshift/Begin/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12)
+cmake_minimum_required(VERSION 3.12)
 project (KokkosTutorialVectorShift)
 
 find_package(KokkosRemote REQUIRED)

--- a/Exercises/vectorshift/Solution/CMakeLists.txt
+++ b/Exercises/vectorshift/Solution/CMakeLists.txt
@@ -1,4 +1,4 @@
-mum_required (VERSION 3.12)
+mum_required(VERSION 3.12)
 project (KokkosTutorialVectorShift)
 
 find_package(KokkosRemote REQUIRED)

--- a/Exercises/virtualfunction/Begin/CMakeLists.txt
+++ b/Exercises/virtualfunction/Begin/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialVirtualFunction)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialVirtualFunction)
 include(../../common.cmake)
 
 add_executable(virtual_function virtual_function.cpp classes.cpp)

--- a/Exercises/virtualfunction/Solution/CMakeLists.txt
+++ b/Exercises/virtualfunction/Solution/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.10)
-project (KokkosTutorialVirtualFunction)
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialVirtualFunction)
 include(../../common.cmake)
 
 add_executable(virtual_function virtual_function.cpp classes.cpp)


### PR DESCRIPTION
CMake v3.16 is the current minimum version required for both Kokkos Core and Kokkos Kernels.
Requiring something more recent than 3.12 enables specifying where to find Kokkos via `-DKokkos_ROOT=/path/to/kokkos/install` which is slightly better than going through `CMAKE_PREFIX_PATH`.

Drop unnecessary/undesirable code to help with finding Kokkos and KokkosKernels.