### PR TITLE
Use CMake FetchContent to build Kokkos Core

### DIFF
--- a/Exercises/common.cmake
+++ b/Exercises/common.cmake
@@ -6,4 +6,18 @@ if(SPACK_CXX)
   set(ENV{CXX} ${SPACK_CXX})
 endif()
 
+include(FetchContent)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+  # try find_package first before trying to download Kokkos
+  set(FETCH_CONTENT_EXTRA_ARGS FIND_PACKAGE_ARGS NAMES Kokkos)
+endif()
+FetchContent_Declare(
+  Kokkos
+  GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+  GIT_TAG        4.0.01
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../dep/Kokkos
+  ${FETCH_CONTENT_EXTRA_ARGS}
+)
+FetchContent_MakeAvailable(Kokkos)
+
 find_package(Kokkos REQUIRED)

--- a/Exercises/common.cmake
+++ b/Exercises/common.cmake
@@ -6,18 +6,29 @@ if(SPACK_CXX)
   set(ENV{CXX} ${SPACK_CXX})
 endif()
 
+set(Kokkos_COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../dep/Kokkos)
+
 include(FetchContent)
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-  # try find_package first before trying to download Kokkos
-  set(FETCH_CONTENT_EXTRA_ARGS FIND_PACKAGE_ARGS NAMES Kokkos)
+  FetchContent_Declare(
+    Kokkos
+    GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+    GIT_TAG        4.0.01
+    SOURCE_DIR ${Kokkos_COMMON_SOURCE_DIR}
+    FIND_PACKAGE_ARGS
+  )
+  FetchContent_MakeAvailable(Kokkos)
+  
+  find_package(Kokkos REQUIRED)
+else()
+  find_package(Kokkos)
+  if(NOT Kokkos_FOUND)
+    FetchContent_Declare(
+      Kokkos
+      GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+      GIT_TAG        4.0.01
+      SOURCE_DIR ${Kokkos_COMMON_SOURCE_DIR}
+    )
+    FetchContent_MakeAvailable(Kokkos)
+  endif()
 endif()
-FetchContent_Declare(
-  Kokkos
-  GIT_REPOSITORY https://github.com/kokkos/kokkos.git
-  GIT_TAG        4.0.01
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../dep/Kokkos
-  ${FETCH_CONTENT_EXTRA_ARGS}
-)
-FetchContent_MakeAvailable(Kokkos)
-
-find_package(Kokkos REQUIRED)

--- a/Exercises/common.cmake
+++ b/Exercises/common.cmake
@@ -8,21 +8,12 @@ endif()
 
 set(Kokkos_COMMON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../dep/Kokkos)
 
-include(FetchContent)
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
-  FetchContent_Declare(
-    Kokkos
-    GIT_REPOSITORY https://github.com/kokkos/kokkos.git
-    GIT_TAG        4.0.01
-    SOURCE_DIR ${Kokkos_COMMON_SOURCE_DIR}
-    FIND_PACKAGE_ARGS
-  )
-  FetchContent_MakeAvailable(Kokkos)
-  
-  find_package(Kokkos REQUIRED)
-else()
-  find_package(Kokkos)
-  if(NOT Kokkos_FOUND)
+find_package(Kokkos CONFIG)
+if(NOT Kokkos_FOUND)
+  if(EXISTS ${Kokkos_COMMON_SOURCE_DIR})
+    add_subdirectory(${Kokkos_COMMON_SOURCE_DIR} Kokkos)
+  else()
+    include(FetchContent)
     FetchContent_Declare(
       Kokkos
       GIT_REPOSITORY https://github.com/kokkos/kokkos.git


### PR DESCRIPTION
Enables doing 
```
cmake -B build-cuda -DKokkos_ENABLE_CUDA=ON
cmake --build build-cuda
./build-cuda/<exe>
cmake -B build-openmp -DKokkos_ENABLE_OPENMP=ON
...
```
One caveat is that, as currently proposed would download Kokkos instead of using an external install.
If using CMake 3.24 one can do
```
cmake -B build -DKokkos_ROOT=/path/to/kokkos/install
...
```
which would bypass the fetch content.

Let me know what you think.
I would do the same for KokkosKernels once we can agree on something