### PR TITLE
Update KokkosKernels exercises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ spack-build/
 spack-build-env.txt
 spack-build-out.txt
 cmake_install.cmake
+CMakeFiles/
+LibInstalls/

--- a/Exercises/kokkoskernels/BlockJacobi/Begin/blockjacobi.cpp
+++ b/Exercises/kokkoskernels/BlockJacobi/Begin/blockjacobi.cpp
@@ -1,6 +1,5 @@
 /// Kokkos headers
 #include "Kokkos_Core.hpp"
-#include "Kokkos_Timer.hpp"
 #include "Kokkos_Random.hpp"
 
 /// KokkosKernels headers

--- a/Exercises/kokkoskernels/BlockJacobi/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/BlockJacobi/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/BlockJacobi/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/BlockJacobi/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/BlockJacobi/Solution/blockjacobi.cpp
+++ b/Exercises/kokkoskernels/BlockJacobi/Solution/blockjacobi.cpp
@@ -1,6 +1,5 @@
 /// Kokkos headers
 #include "Kokkos_Core.hpp"
-#include "Kokkos_Timer.hpp"
 #include "Kokkos_Random.hpp"
 
 /// KokkosKernels headers

--- a/Exercises/kokkoskernels/BlockJacobi/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/BlockJacobi/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/BlockJacobi/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/BlockJacobi/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/CGSolve/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/CGSolve/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/CGSolve/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/CGSolve/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 fi

--- a/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 fi

--- a/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/CGSolve_SpILUKprecond/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/GaussSeidel/Begin/gauss_seidel.cpp
+++ b/Exercises/kokkoskernels/GaussSeidel/Begin/gauss_seidel.cpp
@@ -47,7 +47,7 @@
 #include "Kokkos_Core.hpp"
 #include "KokkosKernels_default_types.hpp"
 #include "KokkosKernels_Handle.hpp"
-#include "KokkosKernels_IOUtils.hpp"
+#include "KokkosSparse_IOUtils.hpp"
 #include "KokkosSparse_spmv.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosSparse_gauss_seidel.hpp"
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
     //Get approx. 20 entries per row
     //Diagonals are 2x the absolute sum of all other entries.
     Offset nnz = numRows * 20;
-    Matrix A = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 2, 100, 1.05 * one);
+    Matrix A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 2, 100, 1.05 * one);
     std::cout << "Generated a matrix with " << numRows << " rows/cols, and " << nnz << " entries.\n";
     //Create a kernel handle, then a Gauss-Seidel handle with the default algorithm
     Handle handle;

--- a/Exercises/kokkoskernels/GaussSeidel/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GaussSeidel/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/GaussSeidel/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GaussSeidel/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/GaussSeidel/Solution/gauss_seidel.cpp
+++ b/Exercises/kokkoskernels/GaussSeidel/Solution/gauss_seidel.cpp
@@ -47,7 +47,7 @@
 #include "Kokkos_Core.hpp"
 #include "KokkosKernels_default_types.hpp"
 #include "KokkosKernels_Handle.hpp"
-#include "KokkosKernels_IOUtils.hpp"
+#include "KokkosSparse_IOUtils.hpp"
 #include "KokkosSparse_spmv.hpp"
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosSparse_gauss_seidel.hpp"
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
     //Get approx. 20 entries per row
     //Diagonals are 2x the absolute sum of all other entries.
     Offset nnz = numRows * 20;
-    Matrix A = KokkosKernels::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 2, 100, 1.05 * one);
+    Matrix A = KokkosSparse::Impl::kk_generate_diagonally_dominant_sparse_matrix<Matrix>(numRows, numRows, nnz, 2, 100, 1.05 * one);
     std::cout << "Generated a matrix with " << numRows << " rows/cols, and " << nnz << " entries.\n";
     //Create a kernel handle, then a Gauss-Seidel handle with the default algorithm
     Handle handle;

--- a/Exercises/kokkoskernels/GaussSeidel/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GaussSeidel/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/GaussSeidel/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GaussSeidel/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/GraphColoring/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GraphColoring/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/GraphColoring/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GraphColoring/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/GraphColoring/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GraphColoring/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/GraphColoring/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/GraphColoring/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/InnerProduct/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/InnerProduct/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/InnerProduct/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/InnerProduct/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/InnerProduct/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/InnerProduct/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/InnerProduct/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/InnerProduct/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/SpGEMM/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpGEMM/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/SpGEMM/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpGEMM/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/SpGEMM/Begin/spgemm.cpp
+++ b/Exercises/kokkoskernels/SpGEMM/Begin/spgemm.cpp
@@ -47,7 +47,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <sys/time.h>
 
 #include <Kokkos_Core.hpp>
 #include <KokkosSparse_CrsMatrix.hpp>
@@ -192,11 +191,6 @@ int main( int argc, char* argv[] )
   
   Kokkos::initialize( argc, argv );
   {
-
-    // Timer products.
-    struct timeval begin, end, s1, s2;
-
-
     // Typedefs
     typedef double scalar_type;
     typedef int ordinal_type;
@@ -220,44 +214,32 @@ int main( int argc, char* argv[] )
     kh.set_dynamic_scheduling(true);
     //kh.set_verbose(true);
 
-
     // EXERCISE: Create the SpGEMM handle
     // EXERCISE hint: std::string myalg("SPGEMM_KK_MEMORY");
     // EXERCISE hint: KokkosSparse::SPGEMMAlgorithm spgemm_algorithm = KokkosSparse::StringToSPGEMMAlgorithm(myalg);
     // EXERCISE hint: kh.create_spgemm_handle(spgemm_algorithm);
 
-
-    gettimeofday( &begin, NULL );
-
     crs_matrix_type C; // First things first: create the output matrix.
 
-    gettimeofday( &s1, NULL );
+    Kokkos::Timer timer;
     // EXERCISE: Call the symbolic phase
     // EXERCISE hint: KokkosSparse::spgemm_symbolic(...) 
 
-    gettimeofday( &s2, NULL );
+    Kokkos::fence();
+    double symbolic_time = timer.seconds();
+    timer.reset();
     // EXERCISE: Call the numeric phase
     // EXERCISE hint: KokkosSparse::spgemm_numeric(...) 
 
-    gettimeofday( &end, NULL );
-
+    Kokkos::fence();
+    double numeric_time = timer.seconds();
 
     // Destroy the SpGEMM handle
     kh.destroy_spgemm_handle();
 
-    // Calculate time.
-    double time = 1.0 *    ( end.tv_sec  - begin.tv_sec ) +
-                  1.0e-6 * ( end.tv_usec - begin.tv_usec );
-
-    double symbolic_time = 1.0 *    ( s2.tv_sec  - s1.tv_sec ) +
-                           1.0e-6 * ( s2.tv_usec - s1.tv_usec );
-
-    double numeric_time = 1.0 *    ( end.tv_sec  - s2.tv_sec ) +
-                          1.0e-6 * ( end.tv_usec - s2.tv_usec );
-
     // Print results (problem size, time, number of iterations and final norm residual).
     printf( "    Results: N( %d ), overall spgemm time( %g s ), symbolic time( %g s ), numeric time( %g s )\n",
-            N, time, symbolic_time, numeric_time);
+            N, symbolic_time + numeric_time, symbolic_time, numeric_time);
   }
 
   Kokkos::finalize();

--- a/Exercises/kokkoskernels/SpGEMM/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpGEMM/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/SpGEMM/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpGEMM/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/SpILUK/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpILUK/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/SpILUK/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpILUK/Begin/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 fi

--- a/Exercises/kokkoskernels/SpILUK/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpILUK/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/SpILUK/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/SpILUK/Solution/run_installlibs_cmake.sh
@@ -1,34 +1,32 @@
 #!/bin/bash
 
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -36,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" -DKokkosKernels_SOURCE_DIR="${KOKKOSKERNELS_PATH}" .
+  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels"  -DKokkosKernels_SOURCE_DIR="$KOKKOSKERNELS_PATH" .
 fi

--- a/Exercises/kokkoskernels/TeamGemm/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/TeamGemm/Begin/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/TeamGemm/Begin/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/TeamGemm/Begin/run_installlibs_cmake.sh
@@ -1,32 +1,32 @@
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+#!/bin/bash
+
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -34,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi

--- a/Exercises/kokkoskernels/TeamGemm/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/TeamGemm/Solution/run_installlibs_cmake.sh
@@ -33,8 +33,4 @@ make install -j8
 cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
-if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
-else
-  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
-fi
+cmake -DKokkosKernels_ROOT="${KOKKOSKERNELS_INSTALL}" .

--- a/Exercises/kokkoskernels/TeamGemm/Solution/run_installlibs_cmake.sh
+++ b/Exercises/kokkoskernels/TeamGemm/Solution/run_installlibs_cmake.sh
@@ -1,32 +1,32 @@
-rm -r CMakeCache.txt CMakeFiles cmake_install.cmake
+#!/bin/bash
+
+rm -r CMakeCache.txt CMakeFiles cmake_install.cmake LibInstalls
 
 KOKKOS_PATH=${HOME}/Kokkos/kokkos
 KOKKOSKERNELS_PATH=${HOME}/Kokkos/kokkos-kernels
 
+CXX_FLAG=
+KOKKOS_ARCH_FLAG=
+
 KOKKOS_DEVICES="Cuda,OpenMP"
-CXX=
-KOKKOS_ARCH=
+# Override the compiler and CPU/GPU architectures here:
+# - add value after --compiler= or --arch=
+# - uncomment the line
+#CXX_FLAG="--compiler="
+#KOKKOS_ARCH_FLAG="--arch="
 TPLS=
 OPTIONS=
 CUDA_OPTIONS=
-
-if [[ "${KOKKOS_DEVICES}" == *Cuda* ]]; then
-  CXX=${KOKKOS_PATH}/bin/nvcc_wrapper
-  KOKKOS_ARCH="BDW,Volta70"
-  CUDA_OPTIONS="enable_lambda"
-else
-  KOKKOS_ARCH="BDW"
-  CXX=g++
-fi
 
 EXERCISE_DIR=${PWD}
 mkdir -p LibInstalls
 KOKKOSKERNELS_INSTALL=${EXERCISE_DIR}/LibInstalls/kernels-install
 cd LibInstalls
 
-echo ${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+CONFIG_CMD="${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash $CXX_FLAG --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} $KOKKOS_ARCH_FLAG --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples --no-default-eti"
 
-${KOKKOSKERNELS_PATH}/cm_generate_makefile.bash --compiler=${CXX} --with-devices=${KOKKOS_DEVICES} --kokkos-path=${KOKKOS_PATH} --kokkoskernels-path=${KOKKOSKERNELS_PATH} --prefix=${KOKKOSKERNELS_INSTALL} --with-options=${OPTIONS} --with-cuda-options=${CUDA_OPTIONS} --arch=${KOKKOS_ARCH} --with-tpls=${TPLS} --kokkos-make-j=8 --disable-kokkos-tests --disable-tests --disable-examples
+echo $CONFIG_CMD
+$CONFIG_CMD
 
 make install -j8
 
@@ -34,7 +34,7 @@ cd ${EXERCISE_DIR}
 
 echo "KERNELS_INSTALL_PATH = $KOKKOSKERNELS_INSTALL"
 if [[ -d "${KOKKOSKERNELS_INSTALL}/lib64" ]]; then
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib64/cmake/KokkosKernels" .
 else
-  cmake -DCMAKE_CXX_COMPILER=${CXX} -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
+  cmake -DKokkosKernels_DIR="${KOKKOSKERNELS_INSTALL}/lib/cmake/KokkosKernels" .
 fi


### PR DESCRIPTION
- Update KK calls that have been moved/renamed
- Change config scripts (run_installlibs_cmake.sh) to be portable, not hardcoded for kokkos-dev-2 architectures
- Build with default ETI off to greatly speed up builds (since a complete installation of KK is created for each program)
- Use Kokkos::Timer instead of gettimeofday()