### PR TITLE
fix header ostream -> iostream

### DIFF
--- a/Exercises/dualview/Begin/dual_view_exercise.cpp
+++ b/Exercises/dualview/Begin/dual_view_exercise.cpp
@@ -41,7 +41,7 @@
 //@HEADER
  */
 
-#include <ostream>
+#include <iostream>
 #include "functors.hpp"
 
 /*

--- a/Exercises/dualview/Solution/dual_view_exercise.cpp
+++ b/Exercises/dualview/Solution/dual_view_exercise.cpp
@@ -41,7 +41,7 @@
 //@HEADER
  */
 
-#include <ostream>
+#include <iostream>
 #include "functors.hpp"
 
 /*


### PR DESCRIPTION
fir compile error 
```shell
dual_view_exercise.cpp(81): error: namespace "std" has no member "cout"
    std::cout << "initializing kokkos....." <<std::endl;
``