### PR TITLE
Add multi-gpu tutorial

### DIFF
--- a/Exercises/multi_gpu_cuda/Begin/CMakeLists.txt
+++ b/Exercises/multi_gpu_cuda/Begin/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialMultiGpuCuda)
+include(../../common.cmake)
+  
+add_executable(ExerciseMultiGPU multi_gpu_cuda.cpp)
+target_link_libraries(ExerciseMultiGPU Kokkos::kokkos)
+

--- a/Exercises/multi_gpu_cuda/Begin/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Begin/multi_gpu_cuda.cpp
@@ -49,6 +49,10 @@ struct CudaStreams {
     //             - Use cudaSetDevice() to direct Cuda API to use particular device
     //             - Destroy stream using cudaStreamDestroy()
   }
+
+  // Removing the following ensure that we manage the lifetime of the streams
+  CudaStreams(const CudaStreams &) = delete;
+  CudaStreams &operator=(const CudaStreams &) = delete;
 };
 
 // EXERCISE: pass in an execution space instance

--- a/Exercises/multi_gpu_cuda/Begin/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Begin/multi_gpu_cuda.cpp
@@ -105,63 +105,62 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  // EXERCISE: create a CudaStreams object
+
   Kokkos::initialize(argc, argv);
   {
-    // EXERCISE: create a CudaStreams object
-    {
-      // EXERCISE: create execution space instances using the streams in CudaStreams
+    // EXERCISE: create execution space instances using the streams in CudaStreams
 
-      // EXERCISE: allocate on device 0
-      ViewVectorType y0("y0", N);
-      ViewVectorType x0("x0", N);
-      ViewMatrixType A0("A0", N, N);
+    // EXERCISE: allocate on device 0
+    ViewVectorType y0("y0", N);
+    ViewVectorType x0("x0", N);
+    ViewMatrixType A0("A0", N, N);
 
-      // EXERCISE: allocate on device 1
-      ViewVectorType y1("y1", N);
-      ViewVectorType x1("x1", N);
-      ViewMatrixType A1("A1", N, N);
+    // EXERCISE: allocate on device 1
+    ViewVectorType y1("y1", N);
+    ViewVectorType x1("x1", N);
+    ViewMatrixType A1("A1", N, N);
 
-      // Timer
-      Kokkos::Timer timer;
+    // Timer
+    Kokkos::Timer timer;
 
-      // EXERCISE: correctly allocate new ResultType
-      ResultType result0;
-      ResultType result1;
-      for (int repeat = 0; repeat < nrepeat; repeat++) {
-        // EXERCISE: pass an execution space instances
-        operation(result0, A0, y0, x0);
-        operation(result1, A1, y1, x1);
+    // EXERCISE: correctly allocate new ResultType
+    ResultType result0;
+    ResultType result1;
+    for (int repeat = 0; repeat < nrepeat; repeat++) {
+      // EXERCISE: pass an execution space instances
+      operation(result0, A0, y0, x0);
+      operation(result1, A1, y1, x1);
 
-        // EXERCISE: process results correctly after changing result type
+      // EXERCISE: process results correctly after changing result type
 
-        // Check results
-        const double solution = (double)N * (double)N;
-        if (result0 != solution) {
-          printf("  Error: result0(%e) != solution(%e)\n", result0, solution);
-        }
-        if (result1 != solution) {
-          printf("  Error: result1(%e) != solution(%e)\n", result1, solution);
-        }
-
-        // Output result.
-        if (repeat == (nrepeat - 1)) {
-          Kokkos::fence();
-          printf("  Computed results for N=%d and nrepeat=%d are %e and %e\n",
-                 N, nrepeat, result0, result1);
-        }
+      // Check results
+      const double solution = (double)N * (double)N;
+      if (result0 != solution) {
+        printf("  Error: result0(%e) != solution(%e)\n", result0, solution);
+      }
+      if (result1 != solution) {
+        printf("  Error: result1(%e) != solution(%e)\n", result1, solution);
       }
 
-      // Calculate time.
-      double time = timer.seconds();
-
-      // Calculate bandwidth.
-      double Gbytes = 2.0e-9 * double(sizeof(double) * (4. * N + 2. * N * N));
-
-      // Print results (problem size, time and bandwidth in GB/s).
-      printf("  N( %ld ) nrepeat ( %d ) problem( %g MB ) time( %g s ) bandwidth( %g GB/s )\n",
-             N, nrepeat, 1.e-6 * (2 * N * N + 4 * N) * sizeof(double), time,
-             Gbytes * nrepeat / time);
+      // Output result.
+      if (repeat == (nrepeat - 1)) {
+        Kokkos::fence();
+        printf("  Computed results for N=%d and nrepeat=%d are %e and %e\n",
+                N, nrepeat, result0, result1);
+      }
     }
+
+    // Calculate time.
+    double time = timer.seconds();
+
+    // Calculate bandwidth.
+    double Gbytes = 2.0e-9 * double(sizeof(double) * (4. * N + 2. * N * N));
+
+    // Print results (problem size, time and bandwidth in GB/s).
+    printf("  N( %ld ) nrepeat ( %d ) problem( %g MB ) time( %g s ) bandwidth( %g GB/s )\n",
+            N, nrepeat, 1.e-6 * (2 * N * N + 4 * N) * sizeof(double), time,
+            Gbytes * nrepeat / time);
   }
   Kokkos::finalize();
 

--- a/Exercises/multi_gpu_cuda/Begin/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Begin/multi_gpu_cuda.cpp
@@ -1,0 +1,167 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+// EXERCISE Goal:
+//   Launch kernels on multiple GPU devices which execute simultaneously
+
+#include <Kokkos_Core.hpp>
+
+#ifndef KOKKOS_ENABLE_CUDA
+#error "This exercise can only be run with Kokkos_ENABLE_CUDA=ON"
+#else
+
+using ExecSpace      = Kokkos::DefaultExecutionSpace;
+using TeamPolicy     = Kokkos::TeamPolicy<ExecSpace>;
+using MemberType     = TeamPolicy::member_type;
+using ViewVectorType = Kokkos::View<double*>;
+using ViewMatrixType = Kokkos::View<double**>;
+
+// EXERCISE: choose a ResultType for parallel_reduce() that will not fence
+using ResultType = double;
+
+struct CudaStreams {
+  std::array<int, 2> devices;
+  std::array<cudaStream_t, 2> streams;
+
+  CudaStreams() {
+    // EXERCISE: query total number of devices available and choose 2: devices = {devid0, devid1}
+    //             - Use cudaGetDeviceCount()
+    // EXERCISE: create a stream on each chosen device
+    //             - Use cudaSetDevice() to direct Cuda API to use particular device
+    //             - Create stream using cudaStreamCreate()
+  }
+
+  ~CudaStreams() {
+    // EXERCISE: for each stream, destroy on the correct device
+    //             - Use cudaSetDevice() to direct Cuda API to use particular device
+    //             - Destroy stream using cudaStreamDestroy()
+  }
+};
+
+// EXERCISE: pass in an execution space instance
+void operation(ResultType& result, ViewMatrixType& A, ViewVectorType& y,
+               ViewVectorType& x) {
+  // Application: <y, Ax> = y^T*A*x
+  const int N = x.extent(0);
+
+  // EXERCISE: deep copy on the correct device
+  Kokkos::deep_copy(y, 1.0);
+  Kokkos::deep_copy(x, 1.0);
+  Kokkos::deep_copy(A, 1.0);
+
+  // EXERCISE: launch team policy on the correct device
+  auto policy = TeamPolicy(N, Kokkos::AUTO, 32);
+  Kokkos::parallel_reduce(
+      "y^TAx", policy,
+      KOKKOS_LAMBDA(const MemberType& team, double& update) {
+        const int j = team.league_rank();
+
+        double temp = 0;
+        Kokkos::parallel_reduce(
+            Kokkos::TeamVectorRange(team, N),
+            [&](const int i, double& innerUpdate) {
+              innerUpdate += A(j, i) * x(i);
+            },
+            temp);
+
+        Kokkos::single(Kokkos::PerTeam(team), [&]() { update += y(j) * temp; });
+      },
+      result);
+}
+
+int main(int argc, char* argv[]) {
+  int N       = 10000;  // number of rows/cols
+  int nrepeat = 100;    // number of repeats of the test
+
+  // Read command line arguments.
+  for (int i = 0; i < argc; i++) {
+    if ((strcmp(argv[i], "-N") == 0) || (strcmp(argv[i], "-Rows") == 0)) {
+      N = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "-nrepeat") == 0) {
+      nrepeat = atoi(argv[++i]);
+    } else if ((strcmp(argv[i], "-h") == 0) ||
+               (strcmp(argv[i], "-help") == 0)) {
+      printf("  -Rows (-N) <int>:      number of rows and colums (default: 10000)\n");
+      printf("  -nrepeat <int>:        number of repetitions (default: 100)\n");
+      printf("  -help (-h):            print this message\n\n");
+      exit(1);
+    }
+  }
+
+  Kokkos::initialize(argc, argv);
+  {
+    // EXERCISE: create a CudaStreams object
+    {
+      // EXERCISE: create execution space instances using the streams in CudaStreams
+
+      // EXERCISE: allocate on device 0
+      ViewVectorType y0("y0", N);
+      ViewVectorType x0("x0", N);
+      ViewMatrixType A0("A0", N, N);
+
+      // EXERCISE: allocate on device 1
+      ViewVectorType y1("y1", N);
+      ViewVectorType x1("x1", N);
+      ViewMatrixType A1("A1", N, N);
+
+      // Timer
+      Kokkos::Timer timer;
+
+      // EXERCISE: correctly allocate new ResultType
+      ResultType result0;
+      ResultType result1;
+      for (int repeat = 0; repeat < nrepeat; repeat++) {
+        // EXERCISE: pass an execution space instances
+        operation(result0, A0, y0, x0);
+        operation(result1, A1, y1, x1);
+
+        // EXERCISE: process results correctly after changing result type
+
+        // Check results
+        const double solution = (double)N * (double)N;
+        if (result0 != solution) {
+          printf("  Error: result0(%e) != solution(%e)\n", result0, solution);
+        }
+        if (result1 != solution) {
+          printf("  Error: result1(%e) != solution(%e)\n", result1, solution);
+        }
+
+        // Output result.
+        if (repeat == (nrepeat - 1)) {
+          Kokkos::fence();
+          printf("  Computed results for N=%d and nrepeat=%d are %e and %e\n",
+                 N, nrepeat, result0, result1);
+        }
+      }
+
+      // Calculate time.
+      double time = timer.seconds();
+
+      // Calculate bandwidth.
+      double Gbytes = 2.0e-9 * double(sizeof(double) * (4. * N + 2. * N * N));
+
+      // Print results (problem size, time and bandwidth in GB/s).
+      printf("  N( %ld ) nrepeat ( %d ) problem( %g MB ) time( %g s ) bandwidth( %g GB/s )\n",
+             N, nrepeat, 1.e-6 * (2 * N * N + 4 * N) * sizeof(double), time,
+             Gbytes * nrepeat / time);
+    }
+  }
+  Kokkos::finalize();
+
+  return 0;
+}
+
+#endif

--- a/Exercises/multi_gpu_cuda/Solution/CMakeLists.txt
+++ b/Exercises/multi_gpu_cuda/Solution/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
+project(KokkosTutorialMultiGpuCuda)
+include(../../common.cmake)
+
+add_executable(ExerciseMultiGPU multi_gpu_cuda.cpp)
+target_link_libraries(ExerciseMultiGPU Kokkos::kokkos)
+

--- a/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
@@ -1,0 +1,189 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <Kokkos_Core.hpp>
+
+#ifndef KOKKOS_ENABLE_CUDA
+#error "This exercise can only be run with Kokkos_ENABLE_CUDA=ON"
+#else
+
+using HostSpace      = Kokkos::HostSpace;
+using ExecSpace      = Kokkos::DefaultExecutionSpace;
+using TeamPolicy     = Kokkos::TeamPolicy<ExecSpace>;
+using MemberType     = TeamPolicy::member_type;
+using ViewVectorType = Kokkos::View<double*>;
+using ViewMatrixType = Kokkos::View<double**>;
+
+// Use a view result type for parallel reduce to avoid fencing over all
+// execution spaces. Without this the kernels will run serially.
+using ResultType = Kokkos::View<double>;
+
+struct CudaStreams {
+  std::array<int, 2> devices;
+  std::array<cudaStream_t, 2> streams;
+
+  CudaStreams() {
+    // Query number of devices available
+    int n_devices;
+    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
+
+    // Chose 2 devices for this tutorial
+    devices = {0, n_devices - 1};
+
+    for (auto i = 0; i < devices.size(); ++i) {
+      // Set device for Cuda API calls
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[i]));
+
+      // Create Cuda stream
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&streams[i]));
+    }
+  }
+
+  ~CudaStreams() {
+    for (auto i = 0; i < devices.size(); ++i) {
+      // Set device for Cuda API calls
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[i]));
+
+      // Destroy Cuda stream
+      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(streams[i]));
+    }
+  }
+};
+
+void operation(ExecSpace& exec_space, ResultType& result, ViewMatrixType& A,
+               ViewVectorType& y, ViewVectorType& x) {
+  // Application: <y, Ax> = y^T*A*x
+  const int N = x.extent(0);
+
+  // Use execution space for deep_copy to correct device
+  Kokkos::deep_copy(exec_space, y, 1.0);
+  Kokkos::deep_copy(exec_space, x, 1.0);
+  Kokkos::deep_copy(exec_space, A, 1.0);
+
+  // Pass execution space to policy constructor to launch on correct device
+  auto policy = TeamPolicy(exec_space, N, Kokkos::AUTO, 32);
+  Kokkos::parallel_reduce(
+      "y^TAx", policy,
+      KOKKOS_LAMBDA(const MemberType& team, double& update) {
+        const int j = team.league_rank();
+
+        double temp = 0;
+        Kokkos::parallel_reduce(
+            Kokkos::TeamVectorRange(team, N),
+            [&](const int i, double& innerUpdate) {
+              innerUpdate += A(j, i) * x(i);
+            },
+            temp);
+
+        Kokkos::single(Kokkos::PerTeam(team), [&]() { update += y(j) * temp; });
+      },
+      result);
+}
+
+int main(int argc, char* argv[]) {
+  int N       = 10000;  // number of rows/cols
+  int nrepeat = 100;    // number of repeats of the test
+
+  // Read command line arguments.
+  for (int i = 0; i < argc; i++) {
+    if ((strcmp(argv[i], "-N") == 0) || (strcmp(argv[i], "-Rows") == 0)) {
+      N = atoi(argv[++i]);
+    } else if (strcmp(argv[i], "-nrepeat") == 0) {
+      nrepeat = atoi(argv[++i]);
+    } else if ((strcmp(argv[i], "-h") == 0) ||
+               (strcmp(argv[i], "-help") == 0)) {
+      printf("  -Rows (-N) <int>:      number of rows and colums (default: 10000)\n");
+      printf("  -nrepeat <int>:        number of repetitions (default: 100)\n");
+      printf("  -help (-h):            print this message\n\n");
+      exit(1);
+    }
+  }
+
+  Kokkos::initialize(argc, argv);
+  {
+    CudaStreams cuda_streams;
+
+    // Scope to ensure all execution spaces and views are destroyed
+    // before the cuda streams themselves are destroyed.
+    {
+      // Use streams to construct execution space on different devices.
+      std::array<ExecSpace, 2> execs = {ExecSpace(cuda_streams.streams[0]),
+                                        ExecSpace(cuda_streams.streams[1])};
+
+      // Allocate views for use on different devices
+      ViewVectorType y0(Kokkos::view_alloc("y0", execs[0]), N);
+      ViewVectorType x0(Kokkos::view_alloc("x0", execs[0]), N);
+      ViewMatrixType A0(Kokkos::view_alloc("A0", execs[0]), N, N);
+
+      ViewVectorType y1(Kokkos::view_alloc("y1", execs[1]), N);
+      ViewVectorType x1(Kokkos::view_alloc("x1", execs[1]), N);
+      ViewMatrixType A1(Kokkos::view_alloc("A1", execs[1]), N, N);
+
+      // Timer
+      Kokkos::Timer timer;
+
+      // Allocate result views for use on different devices
+      ResultType result0(Kokkos::view_alloc("result0", execs[0]));
+      ResultType result1(Kokkos::view_alloc("result1", execs[1]));
+      for (int repeat = 0; repeat < nrepeat; repeat++) {
+        // Pass execution space instances for deep copying and launching
+        // kernels on different devices
+        operation(execs[0], result0, A0, y0, x0);
+        operation(execs[1], result1, A1, y1, x1);
+
+        // Get results on host
+        auto result0_h =
+            Kokkos::create_mirror_view_and_copy(HostSpace(), result0);
+        auto result1_h =
+            Kokkos::create_mirror_view_and_copy(HostSpace(), result1);
+
+        // Check results
+        const double solution = (double)N * (double)N;
+        if (result0_h() != solution) {
+          printf("  Error: result0(%e) != solution(%e)\n", result0_h(),
+                 solution);
+        }
+        if (result1_h() != solution) {
+          printf("  Error: result1(%e) != solution(%e)\n", result1_h(),
+                 solution);
+        }
+
+        // Output results
+        if (repeat == (nrepeat - 1)) {
+          Kokkos::fence();
+          printf("  Computed results for N=%d and nrepeat=%d are %e and %e\n",
+                 N, nrepeat, result0_h(), result1_h());
+        }
+      }
+
+      // Calculate time.
+      double time = timer.seconds();
+
+      // Calculate bandwidth.
+      double Gbytes = 2.0e-9 * double(sizeof(double) * (4. * N + 2. * N * N));
+
+      // Print results (problem size, time and bandwidth in GB/s).
+      printf("  N( %ld ) nrepeat ( %d ) problem( %g MB ) time( %g s ) bandwidth( %g GB/s )\n",
+             N, nrepeat, 1.e-6 * (2 * N * N + 4 * N) * sizeof(double), time,
+             Gbytes * nrepeat / time);
+    }
+  }
+  Kokkos::finalize();
+
+  return 0;
+}
+
+#endif

--- a/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
@@ -40,7 +40,7 @@ struct CudaStreams {
     int n_devices;
     cudaGetDeviceCount(&n_devices);
 
-    // Chose 2 devices for this tutorial
+    // Choose 2 devices for this tutorial
     devices = {0, n_devices - 1};
 
     for (auto i = 0; i < devices.size(); ++i) {

--- a/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
@@ -38,27 +38,27 @@ struct CudaStreams {
   CudaStreams() {
     // Query number of devices available
     int n_devices;
-    KOKKOS_IMPL_CUDA_SAFE_CALL(cudaGetDeviceCount(&n_devices));
+    cudaGetDeviceCount(&n_devices);
 
     // Chose 2 devices for this tutorial
     devices = {0, n_devices - 1};
 
     for (auto i = 0; i < devices.size(); ++i) {
       // Set device for Cuda API calls
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[i]));
+      cudaSetDevice(devices[i]);
 
       // Create Cuda stream
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamCreate(&streams[i]));
+      cudaStreamCreate(&streams[i]);
     }
   }
 
   ~CudaStreams() {
     for (auto i = 0; i < devices.size(); ++i) {
       // Set device for Cuda API calls
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaSetDevice(devices[i]));
+      cudaSetDevice(devices[i]);
 
       // Destroy Cuda stream
-      KOKKOS_IMPL_CUDA_SAFE_CALL(cudaStreamDestroy(streams[i]));
+      cudaStreamDestroy(streams[i]);
     }
   }
 };

--- a/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
+++ b/Exercises/multi_gpu_cuda/Solution/multi_gpu_cuda.cpp
@@ -61,6 +61,10 @@ struct CudaStreams {
       cudaStreamDestroy(streams[i]);
     }
   }
+
+  // Removing the following ensure that we manage the lifetime of the streams
+  CudaStreams(const CudaStreams &) = delete;
+  CudaStreams &operator=(const CudaStreams &) = delete;
 };
 
 void operation(ExecSpace& exec_space, ResultType& result, ViewMatrixType& A,


### PR DESCRIPTION
Add an exercise for muli gpu. Uses the `yT*A*x` example common in many other exercises. 

The `Begin/` part of the exercise can be run where the `yTAx` computation is done with 2 different sets of y,A,x views all on the same device. Then the `Solution/` is to split the computation between 2 different devices, hopefully seeing a 2x speedup. 

I ran on weaver (V100) and got
```
Begin:
  N( 10000 ) nrepeat ( 100 ) problem( 1600.32 MB ) time( 2.48559 s ) bandwidth( 128.768 GB/s )

Solution:
  N( 10000 ) nrepeat ( 100 ) problem( 1600.32 MB ) time( 1.25715 s ) bandwidth( 254.596 GB/s )
```