### PR TITLE
Remove ancient Spack code

### DIFF
--- a/Exercises/common.cmake
+++ b/Exercises/common.cmake
@@ -1,11 +1,3 @@
-
-set(SPACK_CXX $ENV{SPACK_CXX})
-if(SPACK_CXX)
-  message("found spack compiler ${SPACK_CXX}")
-  set(CMAKE_CXX_COMPILER ${SPACK_CXX} CACHE STRING "the C++ compiler" FORCE)
-  set(ENV{CXX} ${SPACK_CXX})
-endif()
-
 if(NOT CMAKE_BUILD_TYPE)
   set(default_build_type "RelWithDebInfo")
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")

--- a/Exercises/fortran-kokkosinterface/Begin/CMakeLists.txt
+++ b/Exercises/fortran-kokkosinterface/Begin/CMakeLists.txt
@@ -4,21 +4,5 @@ include(../../common.cmake)
 
 enable_language(Fortran)
 
-set(SPACK_FC $ENV{SPACK_FC})
-if(SPACK_FC)
-  message("Found spack fortran compiler ${SPACK_FC}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_FC} CACHE STRING "the C++ compiler" FORCE)
-  set(ENV{FC} ${SPACK_FC})
-endif()
-
-set(SPACK_F77 $ENV{SPACK_F77})
-if(SPACK_F77)
-  message("Found spack fortran compiler ${SPACK_F77}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_F77} CACHE STRING "the C++ compiler" FORCE)
-  set(ENV{F77} ${SPACK_F77})
-endif()
-
 add_executable(ftest.x abi.f90 f_interface.f90 main.f90 c_interface.cpp)
 target_link_libraries(ftest.x Kokkos::kokkos)
-
-

--- a/Exercises/fortran-kokkosinterface/Solution/CMakeLists.txt
+++ b/Exercises/fortran-kokkosinterface/Solution/CMakeLists.txt
@@ -2,20 +2,6 @@ cmake_minimum_required(VERSION 3.16)
 project(KokkosTutorialFortran)
 include(../../common.cmake)
 
-set(SPACK_FC $ENV{SPACK_FC})
-if(SPACK_FC)
-  message("Found spack fortran compiler ${SPACK_FC}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_FC} CACHE FILEPATH "the C++ compiler" FORCE)
-  set(ENV{FC} ${SPACK_FC})
-endif()
-
-set(SPACK_F77 $ENV{SPACK_F77})
-if(SPACK_F77)
-  message("Found spack fortran compiler ${SPACK_F77}")
-  set(CMAKE_Fortran_COMPILER ${SPACK_F77} CACHE FILEPATH "the C++ compiler" FORCE)
-  set(ENV{F77} ${SPACK_F77})
-endif()
-
 execute_process (
     COMMAND bash -c "printenv"
     OUTPUT_VARIABLE outVar
@@ -26,5 +12,3 @@ enable_language(Fortran)
 
 add_executable(ftest.x abi.f90 f_interface.f90 main.f90 c_interface.cpp)
 target_link_libraries(ftest.x Kokkos::kokkos)
-
-

--- a/Exercises/kokkoskernels/common.cmake
+++ b/Exercises/kokkoskernels/common.cmake
@@ -1,9 +1,1 @@
-
-set(SPACK_CXX $ENV{SPACK_CXX})
-if(SPACK_CXX)
-  message("found spack compiler ${SPACK_CXX}")
-  set(CMAKE_CXX_COMPILER ${SPACK_CXX} CACHE STRING "the C++ compiler" FORCE)  
-  set(ENV{CXX} ${SPACK_CXX})
-endif()
-
 find_package(KokkosKernels REQUIRED)

--- a/Intro-Full/BuildScripts/kk-spack.sh
+++ b/Intro-Full/BuildScripts/kk-spack.sh
@@ -1,4 +1,0 @@
-#! /bin/bash -ex
-
-spack diy -u cmake kokkos-kernels-tutorial@diy $@
-

--- a/Intro-Full/BuildScripts/spack.sh
+++ b/Intro-Full/BuildScripts/spack.sh
@@ -1,4 +1,0 @@
-#! /bin/bash -ex
-
-spack diy -u cmake kokkos-tutorial@diy $@
-


### PR DESCRIPTION
`spack` support in tutorials was relying on `spack diy` command that is not available anymore.