### PR TITLE
Add spack environments for Kokkos and Kokkos-Kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 spack-build/
 spack-build-env.txt
 spack-build-out.txt
+spack.lock
+.spack-env/
 cmake_install.cmake
 CMakeFiles/
 LibInstalls/

--- a/README.md
+++ b/README.md
@@ -81,3 +81,39 @@ in the `Exercises` directory.
 Compatible means:
  * X86 with a NVIDIA V100 GPU
  * kokkos was cloned to ${HOME}/Kokkos/kokkos
+
+# Using `spack` to build Kokkos and Kokkos-Kernels
+
+[`spack`](https://spack.io) is a package manager for supercomputers, Linux, and macOS. It makes installing scientific
+software easy. With `spack`, you can build Kokkos and its dependencies with a single command.
+
+We provide environments to ease the setup of Kokkos and Kokkos-Kernels for the tutorials. The environments are located
+in the `spack-envs` directory.
+
+To use the environments, first install `spack` by following the
+instructions [here](https://spack.readthedocs.io/en/latest/getting_started.html).
+
+To build Kokkos and Kokkos-Kernels with OpenMP backend, you can use the following commands:
+
+```bash
+source <spack_install_dir>/share/spack/setup-env.sh
+spack compiler add  # find compilers on your system
+spack env activate spack-envs/kokkos-kernels/openmp
+spack install
+spack load kokkos-kernels
+```
+
+Now you can go to the tutorial directory and build the tutorials using the installed Kokkos-Kernels library.
+
+For example:
+
+```bash
+# Select the exercise, and cheat to the solution directory
+cd Exercises/kokkoskernels/GaussSeidel/Solution
+# Configure the build
+cmake -B build_dir
+# Build the exercise
+cmake --build build_dir
+# Run the exercise
+./build_dir/gauss_seidel
+```

--- a/spack-envs/kokkos-kernels/openmp/spack.yaml
+++ b/spack-envs/kokkos-kernels/openmp/spack.yaml
@@ -1,0 +1,11 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - kokkos-kernels+openmp
+  view: false
+  concretizer:
+    unify: true

--- a/spack-envs/kokkos/openmp/spack.yaml
+++ b/spack-envs/kokkos/openmp/spack.yaml
@@ -1,0 +1,12 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - kokkos+openmp~serial
+  view: false
+  concretizer:
+    unify: true
+


### PR DESCRIPTION
These environments are used to build an `OpenMP` enabled stack that can be used to follow some exercises.

It is beneficial for Kokkos-Kernels exercises as Kokkos-Kernels must be built beforehand.

Caveat:
- by default, OpenMP is not available on MacOS, so perhaps providing a `threads` environment is something to do, but I do not know if we want to advertize this backend.