### PR TITLE
Add limited PR testing

### DIFF
--- a/.github/workflows/github-pr-linux-container.yaml
+++ b/.github/workflows/github-pr-linux-container.yaml
@@ -1,0 +1,52 @@
+name: Hosted Runners (linux, CUDA)
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: nvidia/cuda:12.6.2-devel-ubuntu22.04
+    steps:
+    - name: Install cmake
+      run: >
+        apt-get update && apt-get install 
+        -y --no-install-suggests --no-install-recommends
+        cmake
+
+    - name: Checkout Kokkos Tutorials
+      uses: actions/checkout@v4
+      with:
+        path: kokkos-tutorials
+
+    - name: Checkout Kokkos
+      uses: actions/checkout@v4
+      with:
+        repository: 'kokkos/kokkos'
+        ref: master
+        path: kokkos
+
+    - name: Configure Kokkos
+      run: >
+        cmake -S "${GITHUB_WORKSPACE}"/kokkos -B "${GITHUB_WORKSPACE}"/build-kokkos
+        -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}"/install-kokkos
+        -DCMAKE_CXX_COMPILER="${GITHUB_WORKSPACE}"/kokkos/bin/nvcc_wrapper
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DKokkos_ENABLE_CUDA=ON
+        -DKokkos_ARCH_AMPERE80=ON
+        -DKokkos_ENABLE_COMPILER_WARNINGS=ON
+
+    - name: Build & Install Kokkos
+      run: cmake --build "${GITHUB_WORKSPACE}"/build-kokkos --config RelWithDebInfo --parallel 2 --target install
+
+    - name: Configure and Build Exercises
+      run: |
+        bash "${GITHUB_WORKSPACE}"/kokkos-tutorials/Scripts/ci-configure-build-test.sh \
+        "${GITHUB_WORKSPACE}"/install-kokkos/lib/cmake/Kokkos \
+        "${GITHUB_WORKSPACE}"/kokkos-tutorials \
+        "${GITHUB_WORKSPACE}"/kokkos/bin/nvcc_wrapper \
+        RelWithDebInfo \
+        CUDA

--- a/.github/workflows/github-pr-linux-container.yaml
+++ b/.github/workflows/github-pr-linux-container.yaml
@@ -44,7 +44,6 @@ jobs:
         -DCMAKE_BUILD_TYPE=RelWithDebInfo
         -DKokkos_ENABLE_CUDA=ON
         -DKokkos_ARCH_AMPERE80=ON
-        -DKokkos_ENABLE_COMPILER_WARNINGS=ON
 
     - name: Build & Install Kokkos
       run: cmake --build "${GITHUB_WORKSPACE}"/build-kokkos --config RelWithDebInfo --parallel 2 --target install

--- a/.github/workflows/github-pr-linux-container.yaml
+++ b/.github/workflows/github-pr-linux-container.yaml
@@ -29,6 +29,13 @@ jobs:
         ref: master
         path: kokkos
 
+    - name: Checkout Kokkos Kernels
+      uses: actions/checkout@v4
+      with:
+        repository: 'kokkos/kokkos-kernels'
+        ref: master
+        path: kokkos-kernels
+
     - name: Configure Kokkos
       run: >
         cmake -S "${GITHUB_WORKSPACE}"/kokkos -B "${GITHUB_WORKSPACE}"/build-kokkos
@@ -42,10 +49,22 @@ jobs:
     - name: Build & Install Kokkos
       run: cmake --build "${GITHUB_WORKSPACE}"/build-kokkos --config RelWithDebInfo --parallel 2 --target install
 
+    - name: Configure Kokkos Kernels
+      run: >
+        cmake -S "${GITHUB_WORKSPACE}"/kokkos-kernels -B "${GITHUB_WORKSPACE}"/build-kokkos-kernels
+        -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}"/install-kokkos-kernels
+        -DCMAKE_CXX_COMPILER="${GITHUB_WORKSPACE}"/kokkos/bin/nvcc_wrapper
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        -DKokkos_ROOT="${GITHUB_WORKSPACE}"/install-kokkos
+
+    - name: Build & Install Kokkos Kernels
+      run: cmake --build "${GITHUB_WORKSPACE}"/build-kokkos-kernels --config RelWithDebInfo --parallel 2 --target install
+
     - name: Configure and Build Exercises
       run: |
         bash "${GITHUB_WORKSPACE}"/kokkos-tutorials/Scripts/ci-configure-build-test.sh \
         "${GITHUB_WORKSPACE}"/install-kokkos/lib/cmake/Kokkos \
+        "${GITHUB_WORKSPACE}"/install-kokkos-kernels \
         "${GITHUB_WORKSPACE}"/kokkos-tutorials \
         "${GITHUB_WORKSPACE}"/kokkos/bin/nvcc_wrapper \
         RelWithDebInfo \

--- a/.github/workflows/github-pr-linux-container.yaml
+++ b/.github/workflows/github-pr-linux-container.yaml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     container: nvidia/cuda:12.6.2-devel-ubuntu22.04
     steps:
-    - name: Install cmake
+    - name: Install Packages
       run: >
         apt-get update && apt-get install 
         -y --no-install-suggests --no-install-recommends
-        cmake
+        cmake openmpi-bin libopenmpi-dev
 
     - name: Checkout Kokkos Tutorials
       uses: actions/checkout@v4

--- a/.github/workflows/github-pr-unix.yaml
+++ b/.github/workflows/github-pr-unix.yaml
@@ -24,6 +24,16 @@ jobs:
             backend: THREADS
 
     steps:
+    - name: Install Packages
+      run: |
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          sudo apt-get update
+          sudo apt-get install -y --no-install-suggests --no-install-recommends openmpi-bin libopenmpi-dev
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          brew install open-mpi
+        fi
+      shell: bash
+
     - name: Checkout Kokkos Tutorials
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/github-pr-unix.yaml
+++ b/.github/workflows/github-pr-unix.yaml
@@ -1,6 +1,4 @@
-# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
-# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
-name: Hosted Runners
+name: Hosted Runners (unix)
 
 on:
   push:
@@ -16,10 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: windows-latest
-          #   cpp_compiler: cl
-          #   build_type: Release
-          #   backend: SERIAL
           - os: ubuntu-latest
             cpp_compiler: g++
             build_type: RelWithDebInfo
@@ -54,10 +48,10 @@ jobs:
       run: cmake --build ${{ github.workspace}}/build-kokkos --config ${{ matrix.build_type }} --parallel 2 --target install
 
     - name: Configure and Build Exercises
-      run: > 
-        bash ${{ github.workspace}}/kokkos-tutorials/Scripts/ci-configure-build-test.sh
-        ${{ github.workspace}}/install-kokkos/lib/cmake/Kokkos
-        ${{ github.workspace}}/kokkos-tutorials
-        ${{ matrix.cpp_compiler}}
-        ${{ matrix.build_type}}
+      run: |
+        bash ${{ github.workspace}}/kokkos-tutorials/Scripts/ci-configure-build-test.sh \
+        ${{ github.workspace}}/install-kokkos/lib/cmake/Kokkos \
+        ${{ github.workspace}}/kokkos-tutorials \
+        ${{ matrix.cpp_compiler}} \
+        ${{ matrix.build_type}} \
         ${{ matrix.backend }}

--- a/.github/workflows/github-pr-unix.yaml
+++ b/.github/workflows/github-pr-unix.yaml
@@ -36,22 +36,41 @@ jobs:
         ref: master
         path: kokkos
 
+    - name: Checkout Kokkos Kernels
+      uses: actions/checkout@v4
+      with:
+        repository: 'kokkos/kokkos-kernels'
+        ref: master
+        path: kokkos-kernels
+
     - name: Configure Kokkos
       run: >
-        cmake -S ${{ github.workspace}}/kokkos -B ${{ github.workspace}}/build-kokkos
-        -DCMAKE_INSTALL_PREFIX=${{ github.workspace}}/install-kokkos
+        cmake -S "${GITHUB_WORKSPACE}"/kokkos -B "${GITHUB_WORKSPACE}"/build-kokkos
+        -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}"/install-kokkos
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DKokkos_ENABLE_COMPILER_WARNINGS=ON
 
     - name: Build & Install Kokkos
-      run: cmake --build ${{ github.workspace}}/build-kokkos --config ${{ matrix.build_type }} --parallel 2 --target install
+      run: cmake --build "${GITHUB_WORKSPACE}"/build-kokkos --config ${{ matrix.build_type }} --parallel 2 --target install
+
+    - name: Configure Kokkos Kernels
+      run: >
+        cmake -S "${GITHUB_WORKSPACE}"/kokkos-kernels -B "${GITHUB_WORKSPACE}"/build-kokkos-kernels
+        -DCMAKE_INSTALL_PREFIX="${GITHUB_WORKSPACE}"/install-kokkos-kernels
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DKokkos_ROOT="${GITHUB_WORKSPACE}"/install-kokkos
+
+    - name: Build & Install Kokkos Kernels
+      run: cmake --build "${GITHUB_WORKSPACE}"/build-kokkos-kernels --config ${{ matrix.build_type }} --parallel 2 --target install
 
     - name: Configure and Build Exercises
       run: |
-        bash ${{ github.workspace}}/kokkos-tutorials/Scripts/ci-configure-build-test.sh \
-        ${{ github.workspace}}/install-kokkos/lib/cmake/Kokkos \
-        ${{ github.workspace}}/kokkos-tutorials \
+        bash "${GITHUB_WORKSPACE}"/kokkos-tutorials/Scripts/ci-configure-build-test.sh \
+        "${GITHUB_WORKSPACE}"/install-kokkos/lib/cmake/Kokkos \
+        "${GITHUB_WORKSPACE}"/install-kokkos-kernels \
+        "${GITHUB_WORKSPACE}"/kokkos-tutorials \
         ${{ matrix.cpp_compiler}} \
         ${{ matrix.build_type}} \
         ${{ matrix.backend }}

--- a/.github/workflows/github-pr-windows.yaml
+++ b/.github/workflows/github-pr-windows.yaml
@@ -1,0 +1,54 @@
+name: Hosted Runners (windows)
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            cpp_compiler: cl
+            build_type: Release
+            backend: SERIAL
+
+    steps:
+    - name: Checkout Kokkos Tutorials
+      uses: actions/checkout@v4
+      with:
+        path: kokkos-tutorials
+
+    - name: Checkout Kokkos
+      uses: actions/checkout@v4
+      with:
+        repository: 'kokkos/kokkos'
+        ref: master
+        path: kokkos
+
+    - name: Configure Kokkos
+      run: >
+        cmake -S ${{ github.workspace}}\kokkos -B ${{ github.workspace}}\build-kokkos
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace}}\install-kokkos
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build & Install Kokkos
+      run: cmake --build ${{ github.workspace}}\build-kokkos --config ${{ matrix.build_type }} --parallel 2 --target install
+
+    - name: Configure and Build Exercises
+      run: |
+        ${{ github.workspace}}\kokkos-tutorials\Scripts\ci-configure-build-test.bat ^
+        ${{ github.workspace}}\install-kokkos\lib\cmake\Kokkos ^
+        ${{ github.workspace}}\kokkos-tutorials ^
+        ${{ matrix.cpp_compiler}} ^
+        ${{ matrix.build_type}} ^
+        ${{ matrix.backend }}
+      shell: cmd
+        

--- a/.github/workflows/github-pr.yaml
+++ b/.github/workflows/github-pr.yaml
@@ -1,0 +1,63 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: Hosted Runners
+
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # - os: windows-latest
+          #   cpp_compiler: cl
+          #   build_type: Release
+          #   backend: SERIAL
+          - os: ubuntu-latest
+            cpp_compiler: g++
+            build_type: RelWithDebInfo
+            backend: OPENMP
+          - os: macos-latest
+            cpp_compiler: clang++
+            build_type: Debug
+            backend: THREADS
+
+    steps:
+    - name: Checkout Kokkos Tutorials
+      uses: actions/checkout@v4
+      with:
+        path: kokkos-tutorials
+
+    - name: Checkout Kokkos
+      uses: actions/checkout@v4
+      with:
+        repository: 'kokkos/kokkos'
+        ref: master
+        path: kokkos
+
+    - name: Configure Kokkos
+      run: >
+        cmake -S ${{ github.workspace}}/kokkos -B ${{ github.workspace}}/build-kokkos
+        -DCMAKE_INSTALL_PREFIX=${{ github.workspace}}/install-kokkos
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DKokkos_ENABLE_COMPILER_WARNINGS=ON
+
+    - name: Build & Install Kokkos
+      run: cmake --build ${{ github.workspace}}/build-kokkos --config ${{ matrix.build_type }} --parallel 2 --target install
+
+    - name: Configure and Build Exercises
+      run: > 
+        bash ${{ github.workspace}}/kokkos-tutorials/Scripts/ci-configure-build-test.sh
+        ${{ github.workspace}}/install-kokkos/lib/cmake/Kokkos
+        ${{ github.workspace}}/kokkos-tutorials
+        ${{ matrix.cpp_compiler}}
+        ${{ matrix.build_type}}
+        ${{ matrix.backend }}

--- a/Exercises/mpi_exch/CMakeLists.txt
+++ b/Exercises/mpi_exch/CMakeLists.txt
@@ -6,3 +6,4 @@ find_package(MPI REQUIRED)
 
 add_executable(mpi_exch mpi_exch.cpp)
 target_link_libraries(mpi_exch Kokkos::kokkos)
+target_link_libraries(heat3d MPI::MPI_CXX)

--- a/Exercises/mpi_exch/CMakeLists.txt
+++ b/Exercises/mpi_exch/CMakeLists.txt
@@ -6,4 +6,4 @@ find_package(MPI REQUIRED)
 
 add_executable(mpi_exch mpi_exch.cpp)
 target_link_libraries(mpi_exch Kokkos::kokkos)
-target_link_libraries(heat3d MPI::MPI_CXX)
+target_link_libraries(mpi_exch MPI::MPI_CXX)

--- a/Exercises/mpi_heat_conduction/Solution/CMakeLists.txt
+++ b/Exercises/mpi_heat_conduction/Solution/CMakeLists.txt
@@ -6,3 +6,4 @@ find_package(MPI REQUIRED)
 
 add_executable(heat3d mpi_heat_conduction_solution.cpp)
 target_link_libraries(heat3d Kokkos::kokkos)
+target_link_libraries(heat3d MPI::MPI_CXX)

--- a/Scripts/ci-configure-build-test.bat
+++ b/Scripts/ci-configure-build-test.bat
@@ -1,0 +1,32 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+if "%~5"=="" (
+    echo Usage: build.bat kokkos_root tutorials_src cpp_compiler build_type backend
+    exit /b 1
+)
+
+set kokkos_root=%~1
+set tutorials_src=%~2
+set cpp_compiler=%~3
+set build_type=%~4
+set backend=%~5
+
+set "EXERCISES=01 02 03"
+if "%backend%"=="CUDA" set "EXERCISES=%EXERCISES% 04"
+
+set Kokkos_ROOT=%kokkos_root%
+mkdir build 2>nul
+
+for %%e in (%EXERCISES%) do (
+    for %%k in (Begin Solution) do (
+        set "source_dir=%tutorials_src%\Exercises\%%e\%%k"
+        set "build_dir=build\Exercises\%%e\%%k"
+        echo building !source_dir!
+        cmake -S "!source_dir!" -B "!build_dir!" ^
+            -DCMAKE_CXX_COMPILER="%cpp_compiler%" ^
+            -DCMAKE_BUILD_TYPE="%build_type%"
+        
+        cmake --build "!build_dir!" --config "%build_type%"
+    )
+)

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -39,7 +39,6 @@ team_policy
 team_scratch_memory
 team_vector_loop
 unordered_map
-virtualfunction
 )
 
 if [ "$backend" == CUDA ]; then
@@ -47,9 +46,10 @@ if [ "$backend" == CUDA ]; then
   BEGIN_SOLUTION_EXERCISES+=(multi_gpu_cuda)
 fi
 
-# tasking doesn't seem to work on CUDA
+
 if [ ! "$backend" == CUDA ]; then
-  BEGIN_SOLUTION_EXERCISES+=(tasking)
+  BEGIN_SOLUTION_EXERCISES+=(tasking) # tasking doesn't seem to work on CUDA
+  BEGIN_SOLUTION_EXERCISES+=(virtualfunction) # TODO: virtualfunction needs Kokkos with CUDA RDC
 fi
 
 if [ "$backend" == OPENMP ]; then

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -12,18 +12,16 @@ EXERCISES=(
   01
   02
   03
-  04
 )
+
+# Add CUDA exercise when backend is CUDA
+if [ "$backend" == CUDA ]; then
+  EXERCISES+=(04)
+fi
 
 export Kokkos_ROOT="$kokkos_root"
 mkdir -p build
 for e in "${EXERCISES[@]}"; do
-
-  # CUDA hard-coded in, so CUDA needs to be enabled
-  if [ "$e" == 04 ] && [ ! "$backend" == CUDA ]; then
-    continue;
-  fi
-
   for k in Begin Solution; do
     source_dir="$tutorials_src"/Exercises/"$e"/"$k"
     build_dir=build/"$source_dir"

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -24,7 +24,7 @@ mkdir -p build
 for e in "${EXERCISES[@]}"; do
   for k in Begin Solution; do
     source_dir="$tutorials_src"/Exercises/"$e"/"$k"
-    build_dir=build/"$source_dir"
+    build_dir=build/Exercises/"$e"/"$k"
     echo building "$source_dir"
     cmake -S "$source_dir" -B "$build_dir" \
       -DCMAKE_CXX_COMPILER="$cpp_compiler" \

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -3,24 +3,16 @@
 set -eou pipefail
 
 kokkos_root="$1"
-tutorials_src="$2"
-cpp_compiler="$3"
-build_type="$4"
-backend="$5"
+kernels_root="$2"
+tutorials_src="$3"
+cpp_compiler="$4"
+build_type="$5"
+backend="$6"
 
 # These are exercises with CMakeLists.txt in Begin and Solution subdirectories
 # TODO: advanced_reductions seems broken
 # TODO: hpcbind does not use cmake
 # TODO: instances does not use cmake
-# TODO: kokkoskernels/BlockJacobi requires kokkos-kernels
-# TODO: kokkoskernels/CGSolve requires kokkos-kernels
-# TODO: kokkoskernels/CGSolve_SpILUKprecond requires kokkos-kernels
-# TODO: kokkoskernels/GaussSeidel requires kokkos-kernels
-# TODO: kokkoskernels/GraphColoring requires kokkos-kernels
-# TODO: kokkoskernels/InnerProduct requires kokkos-kernels
-# TODO: kokkoskernels/SpGEMM requires kokkos-kernels
-# TODO: kokkoskernels/SpILUK requires kokkos-kernels
-# TODO: kokkoskernels/TeamGemm requires kokkos-kernels
 # TODO: mpi_exch needs MPI
 # TODO: mpi_heat_conduction needs MPI
 # TODO: mpi_pack_unpack needs MPI
@@ -28,11 +20,18 @@ backend="$5"
 # TODO: simd_warp seems broken
 # TODO: subview seems broken
 # TODO: vectorshift needs Kokkos Remote Spaces
+# TODO: kokkoskernels/CGSolve_SpILUKprecond needs to know where Kokkos Kernels source directory is
+# TODO: kokkoskernels/SpILUK needs to know where Kokkos Kernels source directory is
+# TODO: kokkoskernels/TeamGemm seems broken
 BEGIN_SOLUTION_EXERCISES=(
 01
 02
 03
 dualview
+kokkoskernels/BlockJacobi
+kokkoskernels/GaussSeidel
+kokkoskernels/GraphColoring
+kokkoskernels/InnerProduct
 mdrange
 random_number
 scatter_view
@@ -60,6 +59,8 @@ fi
 
 # These are exercises with CMakeLists.txt in the root directory
 EXERCISES=(
+kokkoskernels/CGSolve/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
+kokkoskernels/SpGEMM/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
 tools_minimd
 )
 
@@ -77,7 +78,8 @@ for e in "${EXERCISES[@]}"; do
   echo building "$source_dir"
   cmake -S "$source_dir" -B "$build_dir" \
     -DCMAKE_CXX_COMPILER="$cpp_compiler" \
-    -DCMAKE_BUILD_TYPE="$build_type"
+    -DCMAKE_BUILD_TYPE="$build_type" \
+    -DKokkosKernels_ROOT="$kernels_root"
 
   # --config needed for windows
   cmake --build "$build_dir" --config "$build_type"

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -86,7 +86,6 @@ for e in "${EXERCISES[@]}"; do
     -DCMAKE_CXX_COMPILER="$cpp_compiler" \
     -DCMAKE_BUILD_TYPE="$build_type" \
     -DKokkosKernels_ROOT="$kernels_root"
-
-  # --config needed for windows
-  cmake --build "$build_dir" --config "$build_type"
+    
+  cmake --build "$build_dir"
 done

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -31,7 +31,6 @@ kokkoskernels/GaussSeidel
 kokkoskernels/GraphColoring
 kokkoskernels/InnerProduct
 mdrange
-mpi_exch
 mpi_pack_unpack
 random_number
 scatter_view
@@ -66,6 +65,7 @@ fi
 EXERCISES=(
 kokkoskernels/CGSolve/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
 kokkoskernels/SpGEMM/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
+mpi_exch
 tools_minimd
 )
 

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -36,7 +36,6 @@ mdrange
 random_number
 scatter_view
 simd
-tasking
 team_policy
 team_scratch_memory
 team_vector_loop
@@ -48,6 +47,12 @@ if [ "$backend" == CUDA ]; then
   BEGIN_SOLUTION_EXERCISES+=(04)
   BEGIN_SOLUTION_EXERCISES+=(multi_gpu_cuda)
 fi
+
+# tasking doesn't seem to work on CUDA
+if [ ! "$backend" == CUDA ]; then
+  BEGIN_SOLUTION_EXERCISES+=(tasking)
+fi
+
 if [ "$backend" == OPENMP ]; then
   BEGIN_SOLUTIONS_EXERCISES+=(unique_token)
 fi

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -8,29 +8,77 @@ cpp_compiler="$3"
 build_type="$4"
 backend="$5"
 
-EXERCISES=(
-  01
-  02
-  03
+# These are exercises with CMakeLists.txt in Begin and Solution subdirectories
+# TODO: advanced_reductions seems broken
+# TODO: hpcbind does not use cmake
+# TODO: instances does not use cmake
+# TODO: kokkoskernels/BlockJacobi requires kokkos-kernels
+# TODO: kokkoskernels/CGSolve requires kokkos-kernels
+# TODO: kokkoskernels/CGSolve_SpILUKprecond requires kokkos-kernels
+# TODO: kokkoskernels/GaussSeidel requires kokkos-kernels
+# TODO: kokkoskernels/GraphColoring requires kokkos-kernels
+# TODO: kokkoskernels/InnerProduct requires kokkos-kernels
+# TODO: kokkoskernels/SpGEMM requires kokkos-kernels
+# TODO: kokkoskernels/SpILUK requires kokkos-kernels
+# TODO: kokkoskernels/TeamGemm requires kokkos-kernels
+# TODO: mpi_exch needs MPI
+# TODO: mpi_heat_conduction needs MPI
+# TODO: mpi_pack_unpack needs MPI
+# TODO: parallel_scan seems broken
+# TODO: simd_warp seems broken
+# TODO: subview seems broken
+# TODO: vectorshift needs Kokkos Remote Spaces
+BEGIN_SOLUTION_EXERCISES=(
+01
+02
+03
+dualview
+mdrange
+random_number
+scatter_view
+simd
+tasking
+team_policy
+team_scratch_memory
+team_vector_loop
+unordered_map
+virtualfunction
 )
 
-# Add CUDA exercise when backend is CUDA
 if [ "$backend" == CUDA ]; then
-  EXERCISES+=(04)
+  BEGIN_SOLUTION_EXERCISES+=(04)
+  BEGIN_SOLUTION_EXERCISES+=(multi_gpu_cuda)
 fi
+if [ "$backend" == OPENMP ]; then
+  BEGIN_SOLUTIONS_EXERCISES+=(unique_token)
+fi
+
+# no fortran on macOs
+if [[ ! "$OSTYPE" == "darwin"* ]]; then
+    BEGIN_SOLUTIONS_EXERCISES+=(fortran-kokkosinterface)
+fi
+
+# These are exercises with CMakeLists.txt in the root directory
+EXERCISES=(
+tools_minimd
+)
+
+# Add Begin and Solution subdirectory from BEGIN_SOLUTION_EXCERCISES to EXERCISES
+for e in "${BEGIN_SOLUTION_EXERCISES[@]}"; do
+  EXERCISES+=("$e"/Begin)
+  EXERCISES+=("$e"/Solution)
+done
 
 export Kokkos_ROOT="$kokkos_root"
 mkdir -p build
 for e in "${EXERCISES[@]}"; do
-  for k in Begin Solution; do
-    source_dir="$tutorials_src"/Exercises/"$e"/"$k"
-    build_dir=build/Exercises/"$e"/"$k"
-    echo building "$source_dir"
-    cmake -S "$source_dir" -B "$build_dir" \
-      -DCMAKE_CXX_COMPILER="$cpp_compiler" \
-      -DCMAKE_BUILD_TYPE="$build_type"
-  
-    # --config needed for windows
-    cmake --build "$build_dir" --config "$build_type"
-  done
+  source_dir="$tutorials_src"/Exercises/"$e"
+  build_dir=build/Exercises/"$e"
+  echo building "$source_dir"
+  cmake -S "$source_dir" -B "$build_dir" \
+    -DCMAKE_CXX_COMPILER="$cpp_compiler" \
+    -DCMAKE_BUILD_TYPE="$build_type"
+
+  # --config needed for windows
+  cmake --build "$build_dir" --config "$build_type"
 done

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -13,9 +13,6 @@ backend="$6"
 # TODO: advanced_reductions seems broken
 # TODO: hpcbind does not use cmake
 # TODO: instances does not use cmake
-# TODO: mpi_exch needs MPI
-# TODO: mpi_heat_conduction needs MPI
-# TODO: mpi_pack_unpack needs MPI
 # TODO: parallel_scan seems broken
 # TODO: simd_warp seems broken
 # TODO: subview seems broken
@@ -33,6 +30,8 @@ kokkoskernels/GaussSeidel
 kokkoskernels/GraphColoring
 kokkoskernels/InnerProduct
 mdrange
+mpi_heat_conduction
+mpi_pack_unpack
 random_number
 scatter_view
 simd
@@ -66,6 +65,7 @@ fi
 EXERCISES=(
 kokkoskernels/CGSolve/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
 kokkoskernels/SpGEMM/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
+mpi_exch
 tools_minimd
 )
 

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -20,6 +20,7 @@ backend="$6"
 # TODO: kokkoskernels/CGSolve_SpILUKprecond needs to know where Kokkos Kernels source directory is
 # TODO: kokkoskernels/SpILUK needs to know where Kokkos Kernels source directory is
 # TODO: kokkoskernels/TeamGemm seems broken
+# TODO: mpi_heat_conduction/no-mpi does not use cmake
 BEGIN_SOLUTION_EXERCISES=(
 01
 02
@@ -30,7 +31,7 @@ kokkoskernels/GaussSeidel
 kokkoskernels/GraphColoring
 kokkoskernels/InnerProduct
 mdrange
-mpi_heat_conduction
+mpi_exch
 mpi_pack_unpack
 random_number
 scatter_view
@@ -65,7 +66,7 @@ fi
 EXERCISES=(
 kokkoskernels/CGSolve/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
 kokkoskernels/SpGEMM/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
-mpi_exch
+mpi_heat_condution/Solution # TODO: mpi_heat_conduction/Begin does not use cmake
 tools_minimd
 )
 

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -66,9 +66,13 @@ fi
 EXERCISES=(
 kokkoskernels/CGSolve/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
 kokkoskernels/SpGEMM/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
-mpi_heat_conduction/Solution # TODO: mpi_heat_conduction/Begin does not use cmake
 tools_minimd
 )
+
+# TODO: explicitly specifies CUDA
+if [ "$backend" == CUDA ]; then
+  EXERCISES+=(mpi_heat_conduction/Solution) # TODO: mpi_heat_conduction/Begin does not use cmake
+fi
 
 # Add Begin and Solution subdirectory from BEGIN_SOLUTION_EXCERCISES to EXERCISES
 for e in "${BEGIN_SOLUTION_EXERCISES[@]}"; do

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -66,7 +66,7 @@ fi
 EXERCISES=(
 kokkoskernels/CGSolve/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
 kokkoskernels/SpGEMM/Solution # Begin does not include the proper headers (on purpose) so it can't be compiled
-mpi_heat_condution/Solution # TODO: mpi_heat_conduction/Begin does not use cmake
+mpi_heat_conduction/Solution # TODO: mpi_heat_conduction/Begin does not use cmake
 tools_minimd
 )
 
@@ -86,6 +86,6 @@ for e in "${EXERCISES[@]}"; do
     -DCMAKE_CXX_COMPILER="$cpp_compiler" \
     -DCMAKE_BUILD_TYPE="$build_type" \
     -DKokkosKernels_ROOT="$kernels_root"
-    
+
   cmake --build "$build_dir"
 done

--- a/Scripts/ci-configure-build-test.sh
+++ b/Scripts/ci-configure-build-test.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+
+set -eou pipefail
+
+kokkos_root="$1"
+tutorials_src="$2"
+cpp_compiler="$3"
+build_type="$4"
+backend="$5"
+
+EXERCISES=(
+  01
+  02
+  03
+  04
+)
+
+export Kokkos_ROOT="$kokkos_root"
+mkdir -p build
+for e in "${EXERCISES[@]}"; do
+
+  # CUDA hard-coded in, so CUDA needs to be enabled
+  if [ "$e" == 04 ] && [ ! "$backend" == CUDA ]; then
+    continue;
+  fi
+
+  for k in Begin Solution; do
+    source_dir="$tutorials_src"/Exercises/"$e"/"$k"
+    build_dir=build/"$source_dir"
+    echo building "$source_dir"
+    cmake -S "$source_dir" -B "$build_dir" \
+      -DCMAKE_CXX_COMPILER="$cpp_compiler" \
+      -DCMAKE_BUILD_TYPE="$build_type"
+  
+    # --config needed for windows
+    cmake --build "$build_dir" --config "$build_type"
+  done
+done


### PR DESCRIPTION
Add PR tests a variety of exercises against Kokkos / Kokkos Kernels `master` branches. This only builds the exercises, it does not run their solutions.

Since it's a bit clumsy to build every exercise, this CI uses a script to do it (batch for Windows, bash for Linux/macOS).

- [x] Linux / g++ / OpenMP
- [x] macOS / clang++ / Threads
- [x] Windows / cl / Serial 
- [x] Linux / nvcc / CUDA
- [x] More exercises to test?
- [ ] Run Solutions where possible?

Many exercises did not immediately build, have certain execution spaces hardcoded, or had other problems. Resolving those is left as future work.