### PR TITLE
Fix Begin for advanced_reductions and parallel_scan

### DIFF
--- a/Exercises/advanced_reductions/Begin/advanced_reductions.cpp
+++ b/Exercises/advanced_reductions/Begin/advanced_reductions.cpp
@@ -40,7 +40,8 @@ int main(int argc, char *argv[]) {
         n, KOKKOS_LAMBDA(int i) { view(i) = 1 + i / 10.; });
 
     double result;
-    Kokkos::parallel_reduce(n, GeometricMean{view}, result);
+    /* EXERCISE */
+    // Kokkos::parallel_reduce(n, GeometricMean{view}, result);
 
     auto host_view =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);

--- a/Exercises/parallel_scan/Begin/parallel_scan.cpp
+++ b/Exercises/parallel_scan/Begin/parallel_scan.cpp
@@ -27,7 +27,8 @@ int main(int argc, char *argv[]) {
     int n = 10;
     Kokkos::View<double *> view("view", n);
 
-    Kokkos::parallel_scan(n, Factorial{view});
+    /* EXERCISE */
+    // Kokkos::parallel_scan(n, Factorial(view));
 
     auto host_view =
         Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, view);


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos-tutorials/pull/101/files#r1854601705. The point is to write the interfaces so that the calls to `parallel_reduce` and `parallel_scan` compile and are correct. Hence, we shouldn't actually call them in `Begin` so that the example still compiles.