### PR TITLE
Download latest Kokkos available

### DIFF
--- a/Exercises/common.cmake
+++ b/Exercises/common.cmake
@@ -19,7 +19,7 @@ else()
     FetchContent_Declare(
       Kokkos
       GIT_REPOSITORY https://github.com/kokkos/kokkos.git
-      GIT_TAG        4.3.01
+      GIT_TAG        4.5.01
       SOURCE_DIR ${Kokkos_COMMON_SOURCE_DIR}
     )
     FetchContent_MakeAvailable(Kokkos)


### PR DESCRIPTION
Bump from 4.3.1 to 4.5.1
Motivation for upgrading was some performance degradation in reduction on H100 that has been fixed.
We ran into that at the Kyushu tutorial.