### PR TITLE
MPI heat conduction tutorial execution space instance segfaults on CUDA

### DIFF
--- a/Exercises/mpi_heat_conduction/Solution/CMakeLists.txt
+++ b/Exercises/mpi_heat_conduction/Solution/CMakeLists.txt
@@ -1,7 +1,26 @@
 cmake_minimum_required(VERSION 3.16)
 project(heat3d)
 
-find_package(Kokkos REQUIRED)
+set(KOKKOS_TAG CACHE STRING "Kokkos version tag")
+
+include(FetchContent)
+if(NOT KOKKOS_TAG STREQUAL "")
+  message(STATUS "KOKKOS_TAG=${KOKKOS_TAG}")
+  FetchContent_Declare(
+    Kokkos
+    GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+    GIT_TAG        ${KOKKOS_TAG}
+    FIND_PACKAGE_ARGS NAMES Kokkos::kokkos
+  )
+else()
+  FetchContent_Declare(
+    Kokkos
+    GIT_REPOSITORY https://github.com/kokkos/kokkos.git
+    FIND_PACKAGE_ARGS NAMES Kokkos::kokkos
+  )
+endif()
+FetchContent_MakeAvailable(Kokkos)
+
 find_package(MPI REQUIRED)
 
 add_executable(heat3d mpi_heat_conduction_solution.cpp)

--- a/Exercises/mpi_heat_conduction/Solution/mpi_heat_conduction_solution.cpp
+++ b/Exercises/mpi_heat_conduction/Solution/mpi_heat_conduction_solution.cpp
@@ -118,7 +118,7 @@ struct System {
   // Temperature and delta Temperature
   Kokkos::View<double***> T, dT;
   // Halo data
-  using buffer_t = Kokkos::View<double**,Kokkos::LayoutLeft, Kokkos::CudaSpace>; 
+  using buffer_t = Kokkos::View<double**,Kokkos::LayoutLeft, Kokkos::DefaultExecutionSpace>; 
   buffer_t T_left, T_right, T_up, T_down, T_front, T_back;
   buffer_t T_left_out, T_right_out, T_up_out, T_down_out, T_front_out, T_back_out;
 


### PR DESCRIPTION
This is not really a pull-request. Rather, it's intended as a demonstrator related to comment https://github.com/kokkos/kokkos/pull/8883#issuecomment-4692083902 to https://github.com/kokkos/kokkos/pull/8883

I'm in the process of preparing a corresponding minimal example for Kokkos itself but I'm finding some other issues in the process.

## build

```
rm -rf openmp_511
rm -rf cuda_511
rm -rf cuda_4704
rm -rf openmp_4704

cmake \
  -DKOKKOS_TAG=5.1.1 \
  -DCMAKE_BUILD_TYPE=RELEASE \
  -DKokkos_ENABLE_CUDA=ON \
  -DKokkos_ENABLE_CUDA_CONSTEXPR=ON \
  -DKokkos_ENABLE_OPENMP=ON \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -B cuda_511 \
  -S . \
  --fresh

cmake --build cuda_511 --parallel

cmake \
  -DKOKKOS_TAG=5.1.1 \
  -DCMAKE_BUILD_TYPE=RELEASE \
  -DKokkos_ENABLE_OPENMP=ON \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -B openmp_511 \
  -S . \
  --fresh

cmake --build openmp_511 --parallel

cmake \
  -DKOKKOS_TAG=4.7.04 \
  -DCMAKE_BUILD_TYPE=RELEASE \
  -DKokkos_ENABLE_CUDA=ON \
  -DKokkos_ENABLE_CUDA_CONSTEXPR=ON \
  -DKokkos_ENABLE_OPENMP=ON \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -B cuda_4704 \
  -S . 

cmake --build cuda_4704 --parallel

cmake \
  -DKOKKOS_TAG=4.7.04 \
  -DCMAKE_BUILD_TYPE=RELEASE \
  -DKokkos_ENABLE_OPENMP=ON \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
  -B openmp_4704 \
  -S . 

cmake --build openmp_4704 --parallel
```

# run

```
OMP_NUM_THREADS=4 OMP_PLACES=cores OMP_PROC_BIND=close \
mpirun -np 2 --bind-to none openmp_4704/heat3d -N 10 2>&1 | tee openmp_4704.log

OMP_NUM_THREADS=4 OMP_PLACES=cores OMP_PROC_BIND=close \
mpirun -np 2 --bind-to none cuda_4704/heat3d -N 10 2>&1 | tee cuda_4704.log

OMP_NUM_THREADS=4 OMP_PLACES=cores OMP_PROC_BIND=close \
mpirun -np 2 --bind-to none openmp_511/heat3d -N 10 2>&1 | tee openmp_511.log

OMP_NUM_THREADS=4 OMP_PLACES=cores OMP_PROC_BIND=close \
mpirun -np 2 --bind-to none cuda_511/heat3d -N 10 2>&1 | tee cuda_511.log
```

# results

## OpenMP 4.7.04

```
 $ cat openmp_4704.log
NumRanks: 2 Me: 0 Grid: 1 1 2 MyPos: 0 0 0
Me: 0 MyNeighs: -1 -1 -1 -1 -1 1
My Domain: 0 (0 0 0) (200 200 100)
NumRanks: 2 Me: 1 Grid: 1 1 2 MyPos: 0 0 1
Me: 1 MyNeighs: -1 -1 -1 -1 0 -1
My Domain: 1 (0 0 100) (200 200 200)
0 T=0.000000 Time (0.013669 0.013669)
10 T=2905829.475280 Time (0.143737 0.130068)
```

## OpenMP 5.1.1

```
 $ cat openmp_511.log
NumRanks: 2 Me: 0 Grid: 1 1 2 MyPos: 0 0 0
Me: 0 MyNeighs: -1 -1 -1 -1 -1 1
My Domain: 0 (0 0 0) (200 200 100)
NumRanks: 2 Me: 1 Grid: 1 1 2 MyPos: 0 0 1
Me: 1 MyNeighs: -1 -1 -1 -1 0 -1
My Domain: 1 (0 0 100) (200 200 200)
0 T=0.000000 Time (0.013413 0.013413)
10 T=2905829.475280 Time (0.144137 0.130724)
```

## CUDA 4.7.04

```
 $ cat cuda_4704.log
NumRanks: 2 Me: 1 Grid: 1 1 2 MyPos: 0 0 1
Me: 1 MyNeighs: -1 -1 -1 -1 0 -1
My Domain: 1 (0 0 100) (200 200 200)
NumRanks: 2 Me: 0 Grid: 1 1 2 MyPos: 0 0 0
Me: 0 MyNeighs: -1 -1 -1 -1 -1 1
My Domain: 0 (0 0 0) (200 200 100)
0 T=0.000000 Time (0.083132 0.083132)
10 T=2905829.475281 Time (0.092003 0.008870)
```

## CUDA 5.1.1

```
 $ cat cuda_511.log 
NumRanks: 2 Me: 1 Grid: 1 1 2 MyPos: 0 0 1
Me: 1 MyNeighs: -1 -1 -1 -1 0 -1
My Domain: 1 (0 0 100) (200 200 200)
NumRanks: 2 Me: 0 Grid: 1 1 2 MyPos: 0 0 0
Me: 0 MyNeighs: -1 -1 -1 -1 -1 1
My Domain: 0 (0 0 0) (200 200 100)
0 T=0.000000 Time (0.092405 0.092405)
10 T=2905829.475281 Time (0.099970 0.007565)
[loki:141472:0:141472] Caught signal 11 (Segmentation fault: address not mapped to object at address 0xb471)
[loki:141473:0:141473] Caught signal 11 (Segmentation fault: address not mapped to object at address 0x21cdb)
==== backtrace (tid: 141473) ====
 0 0x000000000003fdf0 __sigaction()  ???:0
 1 0x00000000002d737b cuEGLApiInit()  ???:0
 2 0x0000000000391646 cuVDPAUCtxCreate()  ???:0
 3 0x0000000000386b30 cuStreamSynchronize()  ???:0
 4 0x0000000000013593 ???()  /home/bartek/.local/easybuild/software/CUDA/13.1.0/targets/x86_64-linux/lib/libcudart.so.13:0
 5 0x000000000007fc50 cudaStreamSynchronize()  ???:0
 6 0x0000000000451dd7 Kokkos::Impl::CudaInternal::~CudaInternal()  ???:0
 7 0x00000000004561a1 std::_Function_handler<void (Kokkos::Impl::CudaInternal*), Kokkos::Impl::HostSharedPtr<Kokkos::Impl::CudaInternal>::HostSharedPtr(Kokkos::Impl::CudaInternal*)::{lambda(Kokkos::Impl::CudaInternal*)#1}>::_M_invoke()  ???:0
 8 0x00000000004518ca Kokkos::Cuda::~Cuda()  ???:0
 9 0x000000000040dd70 System::~System()  ???:0
10 0x000000000040811e main()  ???:0
11 0x0000000000029ca8 __libc_init_first()  ???:0
12 0x0000000000029d65 __libc_start_main()  ???:0
13 0x00000000004094d1 _start()  ???:0
=================================
==== backtrace (tid: 141472) ====
 0 0x000000000003fdf0 __sigaction()  ???:0
 1 0x00000000002d737b cuEGLApiInit()  ???:0
 2 0x0000000000391646 cuVDPAUCtxCreate()  ???:0
 3 0x0000000000386b30 cuStreamSynchronize()  ???:0
 4 0x0000000000013593 ???()  /home/bartek/.local/easybuild/software/CUDA/13.1.0/targets/x86_64-linux/lib/libcudart.so.13:0
 5 0x000000000007fc50 cudaStreamSynchronize()  ???:0
 6 0x0000000000451dd7 Kokkos::Impl::CudaInternal::~CudaInternal()  ???:0
 7 0x00000000004561a1 std::_Function_handler<void (Kokkos::Impl::CudaInternal*), Kokkos::Impl::HostSharedPtr<Kokkos::Impl::CudaInternal>::HostSharedPtr(Kokkos::Impl::CudaInternal*)::{lambda(Kokkos::Impl::CudaInternal*)#1}>::_M_invoke()  ???:0
 8 0x00000000004518ca Kokkos::Cuda::~Cuda()  ???:0
 9 0x000000000040dd70 System::~System()  ???:0
10 0x000000000040811e main()  ???:0
11 0x0000000000029ca8 __libc_init_first()  ???:0
12 0x0000000000029d65 __libc_start_main()  ???:0
13 0x00000000004094d1 _start()  ???:0
=================================
[loki:141473] *** Process received signal ***
[loki:141473] Signal: Segmentation fault (11)
[loki:141473] Signal code:  (-6)
[loki:141473] Failing at address: 0x3e8000228a1
[loki:141472] *** Process received signal ***
[loki:141472] Signal: Segmentation fault (11)
[loki:141472] Signal code:  (-6)
[loki:141472] Failing at address: 0x3e8000228a0
[loki:141473] [ 0] [loki:141472] [ 0] /usr/lib/x86_64-linux-gnu/libc.so.6(+0x3fdf0) [0x7f6abd84bdf0]
[loki:141473] [ 1] /usr/lib/x86_64-linux-gnu/libc.so.6(+0x3fdf0) [0x7fcb9fc4bdf0]
[loki:141472] [ 1] /usr/lib/x86_64-linux-gnu/libcuda.so.1(+0x2d737b) [0x7f6abe4d737b]
[loki:141473] [ 2] /usr/lib/x86_64-linux-gnu/libcuda.so.1(+0x2d737b) [0x7fcba08d737b]
[loki:141472] [ 2] /usr/lib/x86_64-linux-gnu/libcuda.so.1(+0x391646) [0x7fcba0991646]
/usr/lib/x86_64-linux-gnu/libcuda.so.1(+0x391646) [0x7f6abe591646]
[loki:141473] [ 3] [loki:141472] [ 3] /usr/lib/x86_64-linux-gnu/libcuda.so.1(cuStreamSynchronize+0x20) [0x7f6abe586b30]
[loki:141473] [ 4] /usr/lib/x86_64-linux-gnu/libcuda.so.1(cuStreamSynchronize+0x20) [0x7fcba0986b30]
[loki:141472] [ 4] /home/bartek/.local/easybuild/software/CUDA/13.1.0/targets/x86_64-linux/lib/libcudart.so.13(+0x13593) [0x7fcba0213593]
[loki:141472] [ 5] /home/bartek/.local/easybuild/software/CUDA/13.1.0/targets/x86_64-linux/lib/libcudart.so.13(+0x13593) [0x7f6abde13593]
[loki:141473] [ 5] /home/bartek/.local/easybuild/software/CUDA/13.1.0/targets/x86_64-linux/lib/libcudart.so.13(cudaStreamSynchronize+0x1d0) [0x7fcba027fc50]
[loki:141472] [ 6] cuda_511/heat3d() [0x451dd7]
[loki:141472] [ 7] /home/bartek/.local/easybuild/software/CUDA/13.1.0/targets/x86_64-linux/lib/libcudart.so.13(cudaStreamSynchronize+0x1d0) [0x7f6abde7fc50]
[loki:141473] [ 6] cuda_511/heat3d() [0x451dd7]
[loki:141473] [ 7] cuda_511/heat3d() [0x4561a1]
[loki:141473] [ 8] cuda_511/heat3d() [0x4518ca]
[loki:141473] [ 9] cuda_511/heat3d() [0x40dd70]
[loki:141473] cuda_511/heat3d() [0x4561a1]
[loki:141472] [ 8] cuda_511/heat3d() [0x4518ca]
[loki:141472] [ 9] cuda_511/heat3d() [0x40dd70]
[loki:141472] [10] [10] cuda_511/heat3d() [0x40811e]
[loki:141473] [11] cuda_511/heat3d() [0x40811e]
[loki:141472] [11] /usr/lib/x86_64-linux-gnu/libc.so.6(+0x29ca8) [0x7f6abd835ca8]
[loki:141473] [12] /usr/lib/x86_64-linux-gnu/libc.so.6(+0x29ca8) [0x7fcb9fc35ca8]
[loki:141472] [12] /usr/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7fcb9fc35d65]
[loki:141472] [13] cuda_511/heat3d() [0x4094d1]
[loki:141472] *** End of error message ***
/usr/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x85) [0x7f6abd835d65]
[loki:141473] [13] cuda_511/heat3d() [0x4094d1]
[loki:141473] *** End of error message ***
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 1 with PID 0 on node loki exited on signal 11 (Segmentation fault).
--------------------------------------------------------------------------
```