### PR TITLE
Update Module 1 online resources

### DIFF
--- a/Content/Presentations/sections/Section_LectureOverview.tex
+++ b/Content/Presentations/sections/Section_LectureOverview.tex
@@ -48,19 +48,18 @@
 		\begin{itemize}
 			\item Primary Kokkos GitHub Organization
 		\end{itemize}
-	\item \url{https://github.com/kokkos/kokkos-tutorials/LectureSeries}: 
+	\item \url{https://kokkos.org/kokkos-tutorials/}:
 		\begin{itemize}
-			\item{Find these slides}
+			\item Built tutorial slides
 		\end{itemize}
 	\item \url{https://kokkos.org}:
 		\begin{itemize}
 			\item Project website including API reference
 		\end{itemize}
-	\item \url{https://kokkosteam.slack.com}: 
+	\item \url{https://kokkosteam.slack.com}:
 		\begin{itemize}
-			\item Slack channel for Kokkos.
-			\item Please join: fastest way to get your questions answered.
-			\item Can whitelist domains, or invite individual people. Email: crtrott@sandia.gov lebrungrandt@ornl.gov
+			\item Ask questions in the \#kokkos-tutorial channel.
+			\item Ask an existing workspace member for an invitation.
 		\end{itemize}
 \end{itemize}
 


### PR DESCRIPTION
## Issue request

Issue #162 assigns Rahul the "Online Resources" slide in Module 1. The requested updates are to direct tutorial questions away from the general Slack channel, link the hosted built PDFs now that binaries are no longer stored in the source repository, and remove obsolete domain-whitelisting instructions.

## Changes

- Replace the obsolete `kokkos-tutorials/LectureSeries` GitHub URL with the hosted tutorials landing page: <https://kokkos.org/kokkos-tutorials/>.
- Label that resource as the location of the built tutorial slides.
- Direct tutorial questions to the `#kokkos-tutorial` Slack channel.
- Replace domain-whitelisting instructions and administrator email addresses with current guidance to ask an existing workspace member for an invitation.

## Validation

- Built the complete Module 1 deck with `make module1` using LuaLaTeX/latexmk (107-page PDF, exit code 0).
- Rendered and visually inspected the updated Online Resources slide; all URLs and Slack guidance are legible with no clipping or overlap.
- Verified the branch contains one commit changing only `Content/Presentations/sections/Section_LectureOverview.tex` and has no whitespace errors.

Addresses part of #162.
